### PR TITLE
Fix Win32 build errors with VS2022 cl.exe

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_POLICY_DEFAULT_CMP0072 NEW)
 set(CMAKE_CXX_STANDARD 14)
 cmake_minimum_required(VERSION 3.4.1)
 
-add_compile_definitions(GL_SILENCE_DEPRECATION MZGL_GL2 MZGL_MAC_GLFW __MACOSX_CORE__)  
+add_compile_definitions(GL_SILENCE_DEPRECATION MZGL_GL2 MZGL_MAC_GLFW)  
 
 add_subdirectory(".." "mzgl-build")
 add_subdirectory(01_App)

--- a/lib/ZipFile/ZipReader.cpp
+++ b/lib/ZipFile/ZipReader.cpp
@@ -193,7 +193,13 @@ std::vector<ZipReader::Entry> readCD(std::ifstream &zip, const ZipEndOfCD &endOf
 	while(offset<cd.size()) {
 		ZipCDEntry *ent = (ZipCDEntry*)(cd.data() + offset);
 		signed char *fileNamePtr = cd.data() + offset + 46;
+
+#ifdef _WIN32
+		char fn[260] = {}; // MAX_PATH
+#else
 		char fn[ent->fileNameLength+1];
+#endif
+
 		fn[ent->fileNameLength] = 0;
 		memcpy(fn, fileNamePtr, ent->fileNameLength);
 //		printf("Compression used: %d\n", ent->compression);

--- a/lib/mzgl/util/stringUtil.cpp
+++ b/lib/mzgl/util/stringUtil.cpp
@@ -10,6 +10,7 @@
 
 #include <sstream>
 #include <iomanip>
+#include <algorithm>
 
 std::string to_string(float value, int precision){
 	std::ostringstream out;

--- a/lib/mzgl/util/util.cpp
+++ b/lib/mzgl/util/util.cpp
@@ -34,6 +34,7 @@
 #include <windows.h>
 #include <winuser.h>
 #include <commdlg.h>
+#include <direct.h>
 #define _WIN32_DCOM
 
 #include <shlobj.h>
@@ -109,12 +110,19 @@ std::string getHomeDirectory() {
 
 
 
+#ifdef _WIN32
+std::string getCWD() {
+    char c[512];
+    _getcwd(c, 512);
+    return c;
+}
+#else
 std::string getCWD() {
     char c[512];
     getcwd(c, 512);
     return c;
 }
-
+#endif
 
 bool copyDir(const fs::path &source, const fs::path &destination, string &errMsg) {
 			


### PR DESCRIPTION
Fixed the first handful of errors I found while building the examples folder locally with latest VS2022 17.3 C++ compiler