### PR TITLE
Use NEON horizontal max rather than std::max

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ lib/glfw/*
 opt/iPlug2
 examples/build/*
 examples/bin/*
+.idea

--- a/lib/mzgl/util/SampleProvider.h
+++ b/lib/mzgl/util/SampleProvider.h
@@ -28,11 +28,24 @@ public:
 
 	// from to to-1 (e.g. end bounds exclusive)
 	virtual void findMinMax(int from, int to, float &min, float &max) const = 0;
+
+	[[nodiscard]] bool operator==(const SampleProvider &other) const {
+		if (this == &other) return true;
+		if (size() != other.size()) return false;
+
+		for (size_t index = 0; index < size(); ++index) {
+			if (std::abs((*this)[index] - other[index]) > 1e-4) {
+				return false;
+			}
+		}
+
+		return true;
+	}
 };
 
 class FloatSampleProvider : public SampleProvider {
 public:
-	virtual ~FloatSampleProvider() {}
+	~FloatSampleProvider() override = default;
 	FloatSampleProvider(const FloatBuffer &data)
 		: data(data) {}
 
@@ -73,14 +86,9 @@ public:
 			maxVec			   = vmaxq_f32(maxVec, values);
 		}
 
-		float resultsMin[4], resultsMax[4];
-		vst1q_f32(resultsMin, minVec);
-		vst1q_f32(resultsMax, maxVec);
+		auto _min = vminvq_f32(minVec);
+		auto _max = vmaxvq_f32(maxVec);
 
-		float _min = std::min({resultsMin[0], resultsMin[1], resultsMin[2], resultsMin[3]});
-		float _max = std::max({resultsMax[0], resultsMax[1], resultsMax[2], resultsMax[3]});
-
-		// Handle any remaining values that aren't a multiple of 4
 		for (int j = from + numIterations * 4; j < to; j++) {
 			float v = this->data[j];
 			if (_max < v) _max = v;

--- a/lib/mzgl/util/SampleProvider.h
+++ b/lib/mzgl/util/SampleProvider.h
@@ -75,27 +75,37 @@ public:
 		// the algo below it
 //#if 0
 #ifdef __ARM_NEON
-		int numIterations = (to - from) / 4; // Each iteration processes 4 values
+        int numIterations = (to - from) / 4; // Each iteration processes 4 values
 
-		float32x4_t minVec = vdupq_n_f32(1);
-		float32x4_t maxVec = vdupq_n_f32(-1);
+        float32x4_t minVec = vdupq_n_f32(1);
+        float32x4_t maxVec = vdupq_n_f32(-1);
 
-		for (int i = 0; i < numIterations; i++) {
-			float32x4_t values = vld1q_f32(this->data.data() + from + i * 4);
-			minVec			   = vminq_f32(minVec, values);
-			maxVec			   = vmaxq_f32(maxVec, values);
-		}
+        for (int i = 0; i < numIterations; i++) {
+            float32x4_t values = vld1q_f32(this->data.data() + from + i * 4);
+            minVec = vminq_f32(minVec, values);
+            maxVec = vmaxq_f32(maxVec, values);
+        }
 
-		auto _min = vminvq_f32(minVec);
-		auto _max = vmaxvq_f32(maxVec);
+#ifdef __ANDROID__
+        float resultsMin[4], resultsMax[4];
+        vst1q_f32(resultsMin, minVec);
+        vst1q_f32(resultsMax, maxVec);
 
-		for (int j = from + numIterations * 4; j < to; j++) {
-			float v = this->data[j];
-			if (_max < v) _max = v;
-			if (_min > v) _min = v;
-		}
-		min = _min;
-		max = _max;
+        auto _min = std::min({resultsMin[0], resultsMin[1], resultsMin[2], resultsMin[3]});
+        auto _max = std::max({resultsMax[0], resultsMax[1], resultsMax[2], resultsMax[3]});
+#else
+        auto _min = vminvq_f32(minVec);
+        auto _max = vmaxvq_f32(maxVec);
+#endif
+
+
+        for (int j = from + numIterations * 4; j < to; j++) {
+            float v = this->data[j];
+            if (_max < v) _max = v;
+            if (_min > v) _min = v;
+        }
+        min = _min;
+        max = _max;
 
 #else
 		// Fallback for platforms without NEON support


### PR DESCRIPTION
Fixes elf-audio/koala#424

In initial testing, one of the slowest areas of the waveform preview was unpacking the Neon vector and performing a `std::max` on the four elements in that vector. Specifically:

```c++

float resultsMin[4], resultsMax[4];
vst1q_f32(resultsMin, minVec);
vst1q_f32(resultsMax, maxVec);

float _min = std::min({resultsMin[0], resultsMin[1], resultsMin[2], resultsMin[3]});
float _max = std::max({resultsMax[0], resultsMax[1], resultsMax[2], resultsMax[3]});

```

Then computation of _max here was the slowest part.
Ive replace that with the [vmaxvq_f32](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxvq_f32) and [vminvq_f32](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminvq_f32) instructions which do a horizontal min/max.

This had the following effects:

## Horizontal std::min

```
benchmark name                       samples       iterations    estimated
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
Preview generation                             100             1    28.5939 ms 
                                        285.568 us    284.296 us    287.295 us 
                                        7.49001 us     5.9249 us    9.51745 us 
```

## using vmaxvq_f32 and vminvq_f32

```
benchmark name                       samples       iterations    estimated
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
Preview generation                             100             1    20.5557 ms 
                                        206.099 us    204.853 us    207.609 us 
                                        6.96792 us    5.99922 us    7.99529 us 
```

So in the average case, this is removing almost 80us per run from the preview generation.