### PR TITLE
Tests for pressure

### DIFF
--- a/lib/mzgl/midi/MidiMessage.h
+++ b/lib/mzgl/midi/MidiMessage.h
@@ -84,6 +84,8 @@ struct MidiMessage {
 	[[nodiscard]] bool isAllNotesOff() const {
 		return status == MIDI_CONTROL_CHANGE && control == MIDI_CC_ALL_NOTES_OFF;
 	}
+	[[nodiscard]] bool isPolyPressure() const { return status == MIDI_POLY_AFTERTOUCH; }
+	[[nodiscard]] bool isChannelPressure() const { return status == MIDI_AFTERTOUCH; }
 	[[nodiscard]] bool isSongPositionPointer() const { return status == MIDI_SONG_POS_POINTER; }
 
 	static MidiMessage noteOn(int channel, int pitch, int velocity) {

--- a/lib/mzgl/test/midiParserTests.cpp
+++ b/lib/mzgl/test/midiParserTests.cpp
@@ -95,3 +95,34 @@ SCENARIO("Delimits multiple note ons off properly", "[midi-parser]") {
 		}
 	}
 }
+
+SCENARIO("Midi messages for aftertouch are valid with channels", "[midi-parser]") {
+	GIVEN("Some midi data and a midi message") {
+		for (int channel = 0; channel < 15; ++channel) {
+			WHEN("Channel " + std::to_string(channel) + " is processed ") {
+				MidiMessage message {{static_cast<unsigned char>(0xD0 + channel), 0x3C}};
+				REQUIRE(message.getBytes().size() == 2);
+				REQUIRE(message.channel == channel + 1);
+				REQUIRE(message.getBytes()[0] == 0xD0 + channel);
+				REQUIRE(message.getBytes()[1] == 0x3C);
+				REQUIRE(message.isChannelPressure());
+			}
+		}
+	}
+}
+
+SCENARIO("Midi messages for polypressure are valid with channels", "[midi-parser]") {
+	GIVEN("Some midi data and a midi message") {
+		for (int channel = 0; channel < 15; ++channel) {
+			WHEN("Channel " + std::to_string(channel) + " is processed ") {
+				MidiMessage message {{static_cast<unsigned char>(0xA0 + channel), 0x3C, 0x64}};
+				REQUIRE(message.channel == channel + 1);
+				REQUIRE(message.getBytes().size() == 3);
+				REQUIRE(message.getBytes()[0] == 0xA0 + channel);
+				REQUIRE(message.getBytes()[1] == 0x3C);
+				REQUIRE(message.getBytes()[2] == 0x64);
+				REQUIRE(message.isPolyPressure());
+			}
+		}
+	}
+}


### PR DESCRIPTION
Resolves #648

So I added some code on Android to inject pressure (both poly and channel) and everything seemed fine.
Then I wrote these tests and everything was fine

One thing I noticed is that the midi channel is shifted by 1 (so an incoming message on 0 is set to channel 1). I started to fix that (because it means that setFromBytes and getBytes in MidiMessage are not orthogonal). But then I realised that it had masses of knock on effects, so I backed out, because it looked *dangerous*. But I think this should be fixed at some point.... 