### PR TITLE
Add midi relative

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,11 @@ set(MZGL_SOURCES
     lib/mzgl/midi/Midi.cpp
     lib/mzgl/midi/AllMidiDevices.cpp
     lib/mzgl/midi/MidiMessage.cpp
+    lib/mzgl/midi/MidiMessage.h
+    lib/mzgl/midi/MidiCCModeDetector.cpp
+    lib/mzgl/midi/MidiCCModeDetector.h
+    lib/mzgl/midi/MidiCCMessageParser.cpp
+    lib/mzgl/midi/MidiCCMessageParser.h
     lib/mzgl/midi/MidiMessageParser.cpp
     lib/mzgl/midi/MidiMessageParser.h
     lib/mzgl/midi/midiMessagePrinting.cpp

--- a/lib/mzgl/midi/MidiCCMessageParser.cpp
+++ b/lib/mzgl/midi/MidiCCMessageParser.cpp
@@ -1,0 +1,168 @@
+#include "MidiCCMessageParser.h"
+#include "mzAssert.h"
+
+MidiCCMessageParser::ChangeType MidiCCMessageParser::determineChange(const MidiMessage &message,
+																	 MidiCCModeDetector::MidiCCMode mode) {
+	switch (mode) {
+		case MidiCCModeDetector::MidiCCMode::Unknown:
+		case MidiCCModeDetector::MidiCCMode::Absolute: return MidiCCMessageParser::ChangeType::NotApplicable;
+		case MidiCCModeDetector::MidiCCMode::TwosComplement: return decodeTwosComplement(message);
+		case MidiCCModeDetector::MidiCCMode::MinMax1: return decodeMinMax1(message);
+		case MidiCCModeDetector::MidiCCMode::MinMax2: return decodeMinMax2(message);
+		case MidiCCModeDetector::MidiCCMode::SignedBit1: return decodeSignedBit1(message);
+		case MidiCCModeDetector::MidiCCMode::SignedBit2: return decodeSignedBit2(message);
+		case MidiCCModeDetector::MidiCCMode::RelativeBinaryOffset: return decodeRelativeBinaryOffset(message);
+		case MidiCCModeDetector::MidiCCMode::ArturiaRelative1: return decodeArturiaRelative1(message);
+		case MidiCCModeDetector::MidiCCMode::ArturiaRelative2: return decodeArturiaRelative2(message);
+		case MidiCCModeDetector::MidiCCMode::ArturiaRelative3: return decodeArturiaRelative3(message);
+	}
+	mzAssert(false);
+	return MidiCCMessageParser::ChangeType::NotApplicable;
+}
+
+std::vector<std::pair<MidiCCMessageParser::ChangeType, std::string>> getMidiCCChangeType() {
+	return {{MidiCCMessageParser::ChangeType::NotApplicable, "NotApplicable"},
+			{MidiCCMessageParser::ChangeType::Positive, "Positive"},
+			{MidiCCMessageParser::ChangeType::Negative, "Negative"},
+			{MidiCCMessageParser::ChangeType::NoChange, "NoChange"}};
+}
+
+std::string MidiCCMessageParser::toString(MidiCCMessageParser::ChangeType type) {
+	auto names = getMidiCCChangeType();
+	auto iter  = std::find_if(names.begin(), names.end(), [type](auto &&pair) { return type == pair.first; });
+	if (iter == names.end()) {
+		throw std::invalid_argument("Invalid ChangeType");
+	}
+	return iter->second;
+}
+
+int MidiCCMessageParser::toValue(MidiCCMessageParser::ChangeType type) {
+	switch (type) {
+		case MidiCCMessageParser::ChangeType::NotApplicable: return 0;
+		case MidiCCMessageParser::ChangeType::Positive: return 1;
+		case MidiCCMessageParser::ChangeType::Negative: return -1;
+		case MidiCCMessageParser::ChangeType::NoChange: return 0;
+	}
+}
+
+MidiCCMessageParser::ChangeType MidiCCMessageParser::toType(const std::string &type) {
+	auto names = getMidiCCChangeType();
+	auto iter  = std::find_if(names.begin(), names.end(), [type](auto &&pair) { return type == pair.second; });
+	if (iter == names.end()) {
+		throw std::invalid_argument("Invalid MidiCCMode string");
+	}
+	return iter->first;
+}
+
+MidiCCMessageParser::ChangeType MidiCCMessageParser::decodeTwosComplement(const MidiMessage &message) {
+	auto dataByte = static_cast<int>(message.getValue());
+	if (dataByte < 0 || dataByte > 127) {
+		return MidiCCMessageParser::ChangeType::NotApplicable;
+	}
+
+	auto delta = dataByte;
+	if (dataByte > 63) {
+		delta = dataByte - 128;
+	}
+
+	if (delta > 0) {
+		return MidiCCMessageParser::ChangeType::Positive;
+	}
+	if (delta < 0) {
+		return MidiCCMessageParser::ChangeType::Negative;
+	}
+	return ChangeType::NoChange;
+}
+
+MidiCCMessageParser::ChangeType MidiCCMessageParser::decodeMinMax1(const MidiMessage &message) {
+	auto [minValue, maxValue] = MidiCCModeDetector::getMinMax1Values();
+	if (message.getValue() == maxValue) {
+		return ChangeType::Negative;
+	}
+	if (message.getValue() == minValue) {
+		return ChangeType::Positive;
+	}
+	return ChangeType::NoChange;
+}
+
+MidiCCMessageParser::ChangeType MidiCCMessageParser::decodeMinMax2(const MidiMessage &message) {
+	auto [minValue, maxValue] = MidiCCModeDetector::getMinMax2Values();
+	if (message.getValue() == maxValue) {
+		return ChangeType::Negative;
+	}
+	if (message.getValue() == minValue) {
+		return ChangeType::Positive;
+	}
+	return ChangeType::NoChange;
+}
+
+MidiCCMessageParser::ChangeType MidiCCMessageParser::decodeSignedBit1(const MidiMessage &message) {
+	auto dataByte = static_cast<int>(message.getValue());
+	if (dataByte < 0 || dataByte > 127) {
+		return MidiCCMessageParser::ChangeType::NotApplicable;
+	}
+
+	int sign	  = (dataByte & 0x40) ? -1 : 1;
+	int magnitude = dataByte & 0x3F;
+
+	if (magnitude == 0) {
+		return MidiCCMessageParser::ChangeType::NoChange;
+	}
+
+	return (sign * magnitude > 0) ? MidiCCMessageParser::ChangeType::Positive
+								  : MidiCCMessageParser::ChangeType::Negative;
+}
+
+MidiCCMessageParser::ChangeType MidiCCMessageParser::decodeSignedBit2(const MidiMessage &message) {
+	auto dataByte = static_cast<int>(message.getValue());
+	if (dataByte < 0 || dataByte > 127) {
+		return MidiCCMessageParser::ChangeType::NotApplicable;
+	}
+
+	int sign	  = (dataByte & 0x40) ? 1 : -1;
+	int magnitude = dataByte & 0x3F;
+
+	if (magnitude == 0) {
+		return MidiCCMessageParser::ChangeType::NoChange;
+	}
+
+	return (sign * magnitude > 0) ? MidiCCMessageParser::ChangeType::Positive
+								  : MidiCCMessageParser::ChangeType::Negative;
+}
+
+MidiCCMessageParser::ChangeType MidiCCMessageParser::decodeRelativeBinaryOffset(const MidiMessage &message) {
+	auto [minValue, maxValue] = MidiCCModeDetector::getRelativeBinaryRange();
+	if (message.getValue() == maxValue) {
+		return ChangeType::Negative;
+	}
+	if (message.getValue() == minValue) {
+		return ChangeType::Positive;
+	}
+	if (message.getValue() == ((maxValue + minValue) / 2)) {
+		return ChangeType::NoChange;
+	}
+	return ChangeType::NoChange;
+}
+
+MidiCCMessageParser::ChangeType MidiCCMessageParser::decodeArturiaRelative1(const MidiMessage &message) {
+	if (message.getValue() == 0) {
+		return ChangeType::NoChange;
+	}
+
+	return (message.getValue() < 64) ? ChangeType::Negative : ChangeType::Positive;
+}
+
+MidiCCMessageParser::ChangeType MidiCCMessageParser::decodeArturiaRelative2(const MidiMessage &message) {
+	if (message.getValue() == 0) {
+		return ChangeType::NoChange;
+	}
+
+	return (message.getValue() <= 3) ? ChangeType::Positive : ChangeType::Negative;
+}
+
+MidiCCMessageParser::ChangeType MidiCCMessageParser::decodeArturiaRelative3(const MidiMessage &message) {
+	if (message.getValue() == 0) {
+		return ChangeType::NoChange;
+	}
+	return (message.getValue() <= 15) ? ChangeType::Negative : ChangeType::Positive;
+}

--- a/lib/mzgl/midi/MidiCCMessageParser.h
+++ b/lib/mzgl/midi/MidiCCMessageParser.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "MidiCCModeDetector.h"
+
+class MidiCCMessageParser {
+public:
+	enum class ChangeType { NotApplicable, Positive, Negative, NoChange };
+
+	[[nodiscard]] ChangeType determineChange(const MidiMessage &message, MidiCCModeDetector::MidiCCMode mode);
+
+	static std::string toString(ChangeType mode);
+	static int toValue(ChangeType mode);
+	static ChangeType toType(const std::string &str);
+
+private:
+	ChangeType decodeTwosComplement(const MidiMessage &message);
+	ChangeType decodeMinMax1(const MidiMessage &message);
+	ChangeType decodeMinMax2(const MidiMessage &message);
+	ChangeType decodeSignedBit1(const MidiMessage &message);
+	ChangeType decodeSignedBit2(const MidiMessage &message);
+	ChangeType decodeRelativeBinaryOffset(const MidiMessage &message);
+	ChangeType decodeArturiaRelative1(const MidiMessage &message);
+	ChangeType decodeArturiaRelative2(const MidiMessage &message);
+	ChangeType decodeArturiaRelative3(const MidiMessage &message);
+};

--- a/lib/mzgl/midi/MidiCCModeDetector.cpp
+++ b/lib/mzgl/midi/MidiCCModeDetector.cpp
@@ -1,0 +1,216 @@
+#include "MidiCCModeDetector.h"
+
+MidiCCModeDetector::MidiCCModeDetector() {
+	for (auto &ccInfo: ccInfos) {
+		ccInfo = CCInfo {};
+	}
+}
+
+void MidiCCModeDetector::process(const MidiMessage &message) {
+	if (!message.isCC()) {
+		return;
+	}
+
+	auto ccIndex = message.getCC();
+	auto value	 = message.getValue();
+
+	if (ccIndex >= numberOfCCs) {
+		throw std::out_of_range("Invalid CC index");
+	}
+
+	ccInfos[ccIndex].buffer.push(value);
+	ccInfos[ccIndex].mode = detectCCMode(ccInfos[ccIndex].buffer);
+}
+
+MidiCCModeDetector::MidiCCMode MidiCCModeDetector::getDetectedMode(uint8_t ccIndex) const {
+	if (ccIndex >= numberOfCCs) {
+		throw std::out_of_range("Invalid CC index");
+	}
+	return ccInfos[ccIndex].mode;
+}
+
+std::vector<std::pair<MidiCCModeDetector::MidiCCMode, std::string>> getMidiCCModeNameMap() {
+	return {
+		{MidiCCModeDetector::MidiCCMode::Absolute, "Absolute"},
+		{MidiCCModeDetector::MidiCCMode::TwosComplement, "TwosComplement"},
+		{MidiCCModeDetector::MidiCCMode::MinMax1, "MinMax1"},
+		{MidiCCModeDetector::MidiCCMode::MinMax2, "MinMax2"},
+		{MidiCCModeDetector::MidiCCMode::RelativeBinaryOffset, "RelativeBinaryOffset"},
+		{MidiCCModeDetector::MidiCCMode::SignedBit1, "SignedBit1"},
+		{MidiCCModeDetector::MidiCCMode::SignedBit2, "SignedBit2"},
+		{MidiCCModeDetector::MidiCCMode::ArturiaRelative1, "ArturiaRelative1"},
+		{MidiCCModeDetector::MidiCCMode::ArturiaRelative2, "ArturiaRelative2"},
+		{MidiCCModeDetector::MidiCCMode::ArturiaRelative3, "ArturiaRelative3"},
+		{MidiCCModeDetector::MidiCCMode::Unknown, "Unknown"},
+	};
+}
+
+std::string MidiCCModeDetector::toString(MidiCCMode mode) {
+	auto names = getMidiCCModeNameMap();
+	auto iter  = std::find_if(names.begin(), names.end(), [mode](auto &&pair) { return mode == pair.first; });
+	if (iter == names.end()) {
+		throw std::invalid_argument("Invalid MidiCCMode");
+	}
+	return iter->second;
+}
+
+MidiCCModeDetector::MidiCCMode MidiCCModeDetector::toMode(const std::string &mode) {
+	auto names = getMidiCCModeNameMap();
+	auto iter  = std::find_if(names.begin(), names.end(), [mode](auto &&pair) { return mode == pair.second; });
+	if (iter == names.end()) {
+		throw std::invalid_argument("Invalid MidiCCMode string");
+	}
+	return iter->first;
+}
+
+std::pair<int, int> MidiCCModeDetector::getMinMax1Values() {
+	static constexpr auto minValue = 1;
+	static constexpr auto maxValue = 127;
+	return {minValue, maxValue};
+}
+
+std::pair<int, int> MidiCCModeDetector::getMinMax2Values() {
+	static constexpr auto minValue = 63;
+	static constexpr auto maxValue = 65;
+	return {minValue, maxValue};
+}
+
+std::pair<int, int> MidiCCModeDetector::getRelativeBinaryRange() {
+	static constexpr auto minValue = 63;
+	static constexpr auto maxValue = 65;
+	return {minValue, maxValue};
+}
+
+std::pair<int, int> MidiCCModeDetector::getArturiaRelative1Range() {
+	static constexpr auto minValue = 61;
+	static constexpr auto maxValue = 67;
+	return {minValue, maxValue};
+}
+
+bool MidiCCModeDetector::allMessagesInRange(const FixedSizeCircularBuffer<uint8_t, maxMessages> &messages,
+											int min,
+											int max,
+											MidiCCModeDetector::CanBeZero canBeZero) {
+	bool foundZero = false;
+	for (auto value: messages) {
+		if ((canBeZero == CanBeZero::Yes || canBeZero == CanBeZero::Must) && value == 0) {
+			foundZero = true;
+			continue;
+		}
+		if (value >= min && value <= max) {
+			continue;
+		}
+		return false;
+	}
+
+	if (canBeZero == CanBeZero::Must) {
+		return foundZero;
+	}
+
+	return true;
+}
+
+bool MidiCCModeDetector::allMessagesInRange(const FixedSizeCircularBuffer<uint8_t, maxMessages> &messages,
+											int range1Min,
+											int range1Max,
+											int range2Min,
+											int range2Max,
+											MidiCCModeDetector::CanBeZero canBeZero) {
+	bool foundZero = false;
+	for (auto value: messages) {
+		if ((canBeZero == CanBeZero::Yes || canBeZero == CanBeZero::Must) && value == 0) {
+			foundZero = true;
+			continue;
+		}
+		if (value >= range1Min && value <= range1Max) {
+			continue;
+		}
+		if (value >= range2Min && value <= range2Max) {
+			continue;
+		}
+		return false;
+	}
+
+	if (canBeZero == CanBeZero::Must) {
+		return foundZero;
+	}
+
+	return true;
+}
+
+bool MidiCCModeDetector::allMessagesExactly(const FixedSizeCircularBuffer<uint8_t, maxMessages> &messages,
+											int min,
+											int max) {
+	for (auto value: messages) {
+		if (value != min && value != max) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool MidiCCModeDetector::isArturiaRelative1(const FixedSizeCircularBuffer<uint8_t, maxMessages> &messages) {
+	auto [minValue, maxValue] = getArturiaRelative1Range();
+	return allMessagesInRange(messages, minValue, maxValue, CanBeZero::Must);
+}
+
+bool MidiCCModeDetector::isArturiaRelative2(const FixedSizeCircularBuffer<uint8_t, maxMessages> &messages) {
+	static constexpr auto range1MinValue = 1;
+	static constexpr auto range1MaxValue = 3;
+	static constexpr auto range2MinValue = 125;
+	static constexpr auto range2MaxValue = 127;
+	return allMessagesInRange(
+		messages, range1MinValue, range1MaxValue, range2MinValue, range2MaxValue, CanBeZero::Must);
+}
+
+bool MidiCCModeDetector::isArturiaRelative3(const FixedSizeCircularBuffer<uint8_t, maxMessages> &messages) {
+	static constexpr auto range1MinValue = 12;
+	static constexpr auto range1MaxValue = 15;
+	static constexpr auto range2MinValue = 17;
+	static constexpr auto range2MaxValue = 19;
+	return allMessagesInRange(
+		messages, range1MinValue, range1MaxValue, range2MinValue, range2MaxValue, CanBeZero::Must);
+}
+
+bool MidiCCModeDetector::isRelativeBinaryOffset(const FixedSizeCircularBuffer<uint8_t, maxMessages> &messages) {
+	auto [minValue, maxValue] = getRelativeBinaryRange();
+	return allMessagesInRange(messages, minValue, maxValue, CanBeZero::No);
+}
+
+bool MidiCCModeDetector::isMinMax1(const FixedSizeCircularBuffer<uint8_t, maxMessages> &messages) {
+	auto [minValue, maxValue] = getMinMax1Values();
+	return allMessagesExactly(messages, minValue, maxValue);
+}
+
+bool MidiCCModeDetector::isMinMax2(const FixedSizeCircularBuffer<uint8_t, maxMessages> &messages) {
+	auto [minValue, maxValue] = getMinMax2Values();
+	return allMessagesExactly(messages, minValue, maxValue);
+}
+
+MidiCCModeDetector::MidiCCMode
+	MidiCCModeDetector::detectCCMode(const FixedSizeCircularBuffer<uint8_t, maxMessages> &messages) {
+	if (messages.empty()) {
+		return MidiCCMode::Unknown;
+	}
+
+	if (isArturiaRelative1(messages)) {
+		return MidiCCModeDetector::MidiCCMode::ArturiaRelative1;
+	}
+	if (isArturiaRelative2(messages)) {
+		return MidiCCModeDetector::MidiCCMode::ArturiaRelative2;
+	}
+	if (isArturiaRelative3(messages)) {
+		return MidiCCModeDetector::MidiCCMode::ArturiaRelative3;
+	}
+	if (isMinMax1(messages)) {
+		return MidiCCModeDetector::MidiCCMode::MinMax1;
+	}
+	if (isMinMax2(messages)) {
+		return MidiCCModeDetector::MidiCCMode::MinMax2;
+	}
+	if (isRelativeBinaryOffset(messages)) {
+		return MidiCCModeDetector::MidiCCMode::RelativeBinaryOffset;
+	}
+
+	return MidiCCMode::Absolute;
+}

--- a/lib/mzgl/midi/MidiCCModeDetector.h
+++ b/lib/mzgl/midi/MidiCCModeDetector.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include <array>
+#include <string>
+#include <stdexcept>
+#include <vector>
+#include <cstdint>
+
+#include "MidiMessage.h"
+#include "FixedSizeCircularBuffer.h"
+
+class MidiCCModeDetector {
+public:
+	enum class MidiCCMode {
+		Unknown,
+		/**
+		 * This is the standard midi CC mode, goes from 0 - 127
+		 */
+		Absolute,
+		/**
+		 * This is described at:
+		 * https://manual.ardour.org/using-control-surfaces/generic-midi/working-with-encoders/
+		 * Note this uses the same range as Absolute range (0 - 127) and thus can't be automatically detected
+		 */
+		TwosComplement,
+		/**
+		 * These are used by Faderfox
+		 * http://www.faderfox.de/PDF/UC4%20Manual%20V03.pdf
+		 */
+		MinMax1,
+		MinMax2,
+		/**
+		 * This is described at:
+		 * https://manual.ardour.org/using-control-surfaces/generic-midi/working-with-encoders/
+		 * https://archive.steinberg.help/cubase_pro/v12/en/cubase_nuendo/topics/midi_remote/midi_remote_item_properties_r.html
+		 * Note this uses the same range as Absolute range (0 - 127) and thus can't be automatically detected
+		 */
+		SignedBit1,
+		SignedBit2,
+		/**
+		 * This is described variously at:
+		 * https://www.ableton.com/en/manual/midi-and-key-remote-control/
+		 * https://manual.ardour.org/using-control-surfaces/generic-midi/working-with-encoders/
+		 * And is also called Enc 3FH/41H in some places
+		 * Note - This is very close to MinMax2, except that it can send 64 to indicate no change
+		 */
+		RelativeBinaryOffset,
+		/**
+		 * These encodings are used in arturia devices. They are documented at:
+		 * http://downloads.arturia.com/products/minilab-mkII/manual/MiniLabmkII_Manual_1_0_7_EN.pdf
+		 * See page 34
+		 */
+		ArturiaRelative1,
+		ArturiaRelative2,
+		ArturiaRelative3,
+	};
+
+	MidiCCModeDetector();
+
+	void process(const MidiMessage &message);
+	[[nodiscard]] MidiCCMode getDetectedMode(uint8_t ccIndex) const;
+
+	static std::string toString(MidiCCMode mode);
+	static MidiCCMode toMode(const std::string &str);
+
+	static std::pair<int, int> getMinMax1Values();
+	static std::pair<int, int> getMinMax2Values();
+	static std::pair<int, int> getRelativeBinaryRange();
+	static std::pair<int, int> getArturiaRelative1Range();
+
+private:
+	static constexpr size_t maxMessages = 10;
+	static constexpr size_t numberOfCCs = 128;
+
+	struct CCInfo {
+		FixedSizeCircularBuffer<uint8_t, maxMessages> buffer;
+		MidiCCMode mode = MidiCCMode::Unknown;
+	};
+
+	std::array<CCInfo, numberOfCCs> ccInfos;
+
+	static MidiCCMode detectCCMode(const FixedSizeCircularBuffer<uint8_t, maxMessages> &messages);
+
+	enum class CanBeZero { Must, Yes, No };
+	static bool allMessagesInRange(const FixedSizeCircularBuffer<uint8_t, maxMessages> &messages,
+								   int min,
+								   int max,
+								   CanBeZero canBeZero);
+	static bool allMessagesInRange(const FixedSizeCircularBuffer<uint8_t, maxMessages> &messages,
+								   int range1Min,
+								   int range1Max,
+								   int range2Min,
+								   int range2Max,
+								   CanBeZero canBeZero);
+	static bool
+		allMessagesExactly(const FixedSizeCircularBuffer<uint8_t, maxMessages> &messages, int min, int max);
+
+	static bool isArturiaRelative1(const FixedSizeCircularBuffer<uint8_t, maxMessages> &messages);
+	static bool isArturiaRelative2(const FixedSizeCircularBuffer<uint8_t, maxMessages> &messages);
+	static bool isArturiaRelative3(const FixedSizeCircularBuffer<uint8_t, maxMessages> &messages);
+	static bool isRelativeBinaryOffset(const FixedSizeCircularBuffer<uint8_t, maxMessages> &messages);
+	static bool isMinMax1(const FixedSizeCircularBuffer<uint8_t, maxMessages> &messages);
+	static bool isMinMax2(const FixedSizeCircularBuffer<uint8_t, maxMessages> &messages);
+};

--- a/lib/mzgl/test/fixedSizeCircularBufferTests.cpp
+++ b/lib/mzgl/test/fixedSizeCircularBufferTests.cpp
@@ -1,0 +1,511 @@
+#include "tests.h"
+#include "FixedSizeCircularBuffer.h"
+
+TEST_CASE("FixedSizeCircularBuffer functionality", "[fixedsizecircularbuffer]") {
+	GIVEN("An empty FixedSizeCircularBuffer of size 5") {
+		FixedSizeCircularBuffer<int, 5> buffer;
+
+		THEN("The buffer should be empty") {
+			REQUIRE(buffer.empty());
+			REQUIRE(buffer.size() == 0);
+		}
+
+		WHEN("An element is pushed into the buffer") {
+			buffer.push(42);
+
+			THEN("The buffer should not be empty") {
+				REQUIRE_FALSE(buffer.empty());
+				REQUIRE(buffer.size() == 1);
+			}
+
+			THEN("The element should be retrievable at index 0") {
+				REQUIRE(buffer[0] == 42);
+			}
+
+			THEN("Accessing out-of-range index should throw an exception") {
+				REQUIRE_THROWS_AS(buffer[1], std::out_of_range);
+			}
+		}
+
+		WHEN("Multiple elements are pushed into the buffer") {
+			buffer.push(1);
+			buffer.push(2);
+			buffer.push(3);
+			buffer.push(4);
+			buffer.push(5);
+
+			THEN("The buffer should be full") {
+				REQUIRE(buffer.size() == 5);
+			}
+
+			THEN("Elements should be retrievable in the correct order") {
+				REQUIRE(buffer[0] == 1);
+				REQUIRE(buffer[1] == 2);
+				REQUIRE(buffer[2] == 3);
+				REQUIRE(buffer[3] == 4);
+				REQUIRE(buffer[4] == 5);
+			}
+
+			WHEN("Additional elements are pushed beyond the buffer's capacity") {
+				buffer.push(6);
+				buffer.push(7);
+
+				THEN("The oldest elements should be overwritten") {
+					REQUIRE(buffer.size() == 5);
+					REQUIRE(buffer[0] == 3);
+					REQUIRE(buffer[1] == 4);
+					REQUIRE(buffer[2] == 5);
+					REQUIRE(buffer[3] == 6);
+					REQUIRE(buffer[4] == 7);
+				}
+			}
+		}
+
+		WHEN("Clearing the buffer after adding elements") {
+			buffer.push(10);
+			buffer.push(20);
+			buffer.clear();
+
+			THEN("The buffer should be empty") {
+				REQUIRE(buffer.empty());
+				REQUIRE(buffer.size() == 0);
+			}
+
+			THEN("Accessing any index should throw an exception") {
+				REQUIRE_THROWS_AS(buffer[0], std::out_of_range);
+			}
+		}
+
+		WHEN("Accessing elements in an empty buffer") {
+			THEN("An exception should be thrown") {
+				REQUIRE_THROWS_AS(buffer[0], std::out_of_range);
+			}
+		}
+	}
+
+	GIVEN("A FixedSizeCircularBuffer of size 3 with initial elements") {
+		FixedSizeCircularBuffer<std::string, 3> buffer;
+		buffer.push("alpha");
+		buffer.push("beta");
+		buffer.push("gamma");
+
+		THEN("The buffer should contain the correct elements") {
+			REQUIRE(buffer.size() == 3);
+			REQUIRE(buffer[0] == "alpha");
+			REQUIRE(buffer[1] == "beta");
+			REQUIRE(buffer[2] == "gamma");
+		}
+
+		WHEN("An additional element is pushed into the full buffer") {
+			buffer.push("delta");
+
+			THEN("The oldest element should be overwritten") {
+				REQUIRE(buffer.size() == 3);
+				REQUIRE(buffer[0] == "beta");
+				REQUIRE(buffer[1] == "gamma");
+				REQUIRE(buffer[2] == "delta");
+			}
+		}
+
+		WHEN("Clearing the buffer") {
+			buffer.clear();
+
+			THEN("The buffer should be empty") {
+				REQUIRE(buffer.empty());
+				REQUIRE(buffer.size() == 0);
+			}
+
+			THEN("Accessing elements should throw an exception") {
+				REQUIRE_THROWS_AS(buffer[0], std::out_of_range);
+			}
+		}
+	}
+
+	GIVEN("A FixedSizeCircularBuffer of size 2") {
+		FixedSizeCircularBuffer<int, 2> buffer;
+
+		WHEN("Pushing one element") {
+			buffer.push(100);
+
+			THEN("Size should be 1") {
+				REQUIRE(buffer.size() == 1);
+			}
+
+			THEN("empty() should return false") {
+				REQUIRE_FALSE(buffer.empty());
+			}
+
+			THEN("Element at index 0 should be correct") {
+				REQUIRE(buffer[0] == 100);
+			}
+		}
+
+		WHEN("Pushing two elements") {
+			buffer.push(200);
+			buffer.push(300);
+
+			THEN("Size should be 2") {
+				REQUIRE(buffer.size() == 2);
+			}
+
+			THEN("Elements should be correct") {
+				REQUIRE(buffer[0] == 200);
+				REQUIRE(buffer[1] == 300);
+			}
+		}
+
+		WHEN("Pushing three elements (overwriting occurs)") {
+			buffer.push(400);
+			buffer.push(500);
+			buffer.push(600);
+
+			THEN("Size should remain 2") {
+				REQUIRE(buffer.size() == 2);
+			}
+
+			THEN("Oldest element should be overwritten") {
+				REQUIRE(buffer[0] == 500);
+				REQUIRE(buffer[1] == 600);
+			}
+		}
+	}
+}
+
+TEST_CASE("FixedSizeCircularBuffer iterator functionality", "[FixedSizeCircularBuffer][Iterator]") {
+	GIVEN("An empty FixedSizeCircularBuffer<int, 5>") {
+		FixedSizeCircularBuffer<int, 5> buffer;
+
+		WHEN("begin() and end() are obtained") {
+			auto it_begin = buffer.begin();
+			auto it_end	  = buffer.end();
+
+			THEN("begin() equals end()") {
+				REQUIRE(it_begin == it_end);
+			}
+
+			THEN("Iterating over the buffer yields no elements") {
+				REQUIRE(it_begin == it_end);
+			}
+		}
+
+		WHEN("Elements are added to the buffer") {
+			buffer.push(10);
+			buffer.push(20);
+			buffer.push(30);
+
+			THEN("begin() and end() define a range of size equal to buffer.size()") {
+				auto it_begin = buffer.begin();
+				auto it_end	  = buffer.end();
+				REQUIRE(std::distance(it_begin, it_end) == buffer.size());
+			}
+
+			THEN("Iterator can be used to traverse the buffer") {
+				std::vector<int> elements;
+				for (auto it = buffer.begin(); it != buffer.end(); ++it) {
+					elements.push_back(*it);
+				}
+				REQUIRE(elements.size() == 3);
+				REQUIRE(elements[0] == 10);
+				REQUIRE(elements[1] == 20);
+				REQUIRE(elements[2] == 30);
+			}
+
+			THEN("Iterator supports std::for_each") {
+				int sum = 0;
+				std::for_each(buffer.begin(), buffer.end(), [&sum](int value) { sum += value; });
+				REQUIRE(sum == 60);
+			}
+
+			THEN("Iterator supports std::accumulate") {
+				int total = std::accumulate(buffer.begin(), buffer.end(), 0);
+				REQUIRE(total == 60);
+			}
+		}
+	}
+
+	GIVEN("A full FixedSizeCircularBuffer<int, 5>") {
+		FixedSizeCircularBuffer<int, 5> buffer;
+		buffer.push(1);
+		buffer.push(2);
+		buffer.push(3);
+		buffer.push(4);
+		buffer.push(5);
+
+		WHEN("An additional element is pushed (causing overwrite)") {
+			buffer.push(6);
+
+			THEN("The buffer contains the last 5 elements") {
+				std::vector<int> elements(buffer.begin(), buffer.end());
+				REQUIRE(elements.size() == 5);
+				REQUIRE(elements[0] == 2);
+				REQUIRE(elements[1] == 3);
+				REQUIRE(elements[2] == 4);
+				REQUIRE(elements[3] == 5);
+				REQUIRE(elements[4] == 6);
+			}
+
+			THEN("Iterator arithmetic works correctly") {
+				auto it = buffer.begin();
+				REQUIRE(*it == 2);
+				it += 2;
+				REQUIRE(*it == 4);
+				it = it + 2;
+				REQUIRE(*it == 6);
+				it = it - 3;
+				REQUIRE(*it == 3);
+			}
+
+			THEN("Iterator comparisons work correctly") {
+				auto it1 = buffer.begin();
+				auto it2 = buffer.begin() + 3;
+				REQUIRE(it1 != it2);
+				REQUIRE(it1 < it2);
+				REQUIRE(it2 > it1);
+				REQUIRE(it1 <= it2);
+				REQUIRE(it2 >= it1);
+			}
+
+			THEN("Difference between iterators is calculated correctly") {
+				auto it_begin = buffer.begin();
+				auto it_end	  = buffer.end();
+				REQUIRE(it_end - it_begin == 5);
+				REQUIRE(it_begin - it_end == -5);
+			}
+		}
+	}
+
+	GIVEN("A FixedSizeCircularBuffer<std::string, 3> with elements") {
+		FixedSizeCircularBuffer<std::string, 3> buffer;
+		buffer.push("alpha");
+		buffer.push("beta");
+		buffer.push("gamma");
+
+		WHEN("Using const_iterator to traverse the buffer") {
+			const auto &const_buffer = buffer;
+			std::vector<std::string> elements(const_buffer.cbegin(), const_buffer.cend());
+
+			THEN("All elements are correctly accessed") {
+				REQUIRE(elements.size() == 3);
+				REQUIRE(elements[0] == "alpha");
+				REQUIRE(elements[1] == "beta");
+				REQUIRE(elements[2] == "gamma");
+			}
+		}
+
+		WHEN("Using reverse iteration") {
+			std::vector<std::string> elements;
+			for (auto it = buffer.end(); it != buffer.begin();) {
+				--it;
+				elements.push_back(*it);
+			}
+
+			THEN("Elements are accessed in reverse order") {
+				REQUIRE(elements.size() == 3);
+				REQUIRE(elements[0] == "gamma");
+				REQUIRE(elements[1] == "beta");
+				REQUIRE(elements[2] == "alpha");
+			}
+		}
+	}
+
+	GIVEN("An iterator pointing to the buffer's begin") {
+		FixedSizeCircularBuffer<int, 5> buffer;
+		buffer.push(100);
+		buffer.push(200);
+
+		auto it = buffer.begin();
+
+		WHEN("Iterator is incremented") {
+			++it;
+
+			THEN("It points to the next element") {
+				REQUIRE(*it == 200);
+			}
+		}
+
+		WHEN("Iterator is advanced beyond end") {
+			it += buffer.size();
+
+			THEN("It equals end()") {
+				REQUIRE(it == buffer.end());
+			}
+
+			THEN("Dereferencing end iterator is invalid") {
+				REQUIRE_THROWS_AS(*it, std::out_of_range);
+			}
+		}
+	}
+
+	GIVEN("Two iterators pointing within the buffer") {
+		FixedSizeCircularBuffer<int, 5> buffer;
+		buffer.push(1);
+		buffer.push(2);
+		buffer.push(3);
+
+		auto it1 = buffer.begin();
+		auto it2 = buffer.begin() + 2;
+
+		WHEN("Calculating the distance between iterators") {
+			auto distance = it2 - it1;
+
+			THEN("The distance is correct") {
+				REQUIRE(distance == 2);
+			}
+		}
+
+		WHEN("Comparing iterators for equality and ordering") {
+			THEN("Iterators are compared correctly") {
+				REQUIRE(it1 != it2);
+				REQUIRE(it1 < it2);
+				REQUIRE(it2 > it1);
+				REQUIRE(it1 <= it2);
+				REQUIRE(it2 >= it1);
+			}
+		}
+	}
+
+	GIVEN("Using STL algorithms with FixedSizeCircularBuffer") {
+		FixedSizeCircularBuffer<int, 10> buffer;
+		for (int i = 1; i <= 15; ++i) {
+			buffer.push(i);
+		}
+
+		WHEN("Using std::find to search for an element") {
+			auto it = std::find(buffer.begin(), buffer.end(), 10);
+
+			THEN("Element is found") {
+				REQUIRE(it != buffer.end());
+				REQUIRE(*it == 10);
+			}
+		}
+
+		WHEN("Using std::count_if to count even numbers") {
+			int count = std::count_if(buffer.begin(), buffer.end(), [](int value) { return value % 2 == 0; });
+
+			THEN("Count is correct") {
+				REQUIRE(count == 5);
+			}
+		}
+
+		WHEN("Using std::copy to copy elements to a vector") {
+			std::vector<int> elements;
+			std::copy(buffer.begin(), buffer.end(), std::back_inserter(elements));
+
+			THEN("All elements are copied") {
+				REQUIRE(elements.size() == 10);
+				REQUIRE(elements[0] == 6);
+				REQUIRE(elements[9] == 15);
+			}
+		}
+	}
+
+	GIVEN("Modifying the buffer invalidates iterators") {
+		FixedSizeCircularBuffer<int, 5> buffer;
+		buffer.push(1);
+		buffer.push(2);
+		buffer.push(3);
+
+		auto it = buffer.begin();
+
+		WHEN("An element is pushed to the buffer") {
+			buffer.push(4);
+
+			THEN("Iterator may be invalidated") {
+				REQUIRE(*it == 1);
+			}
+
+			WHEN("Enough elements are pushed to overwrite the oldest element") {
+				buffer.push(5);
+				buffer.push(6);
+
+				THEN("Iterator may now point to overwritten data") {
+				}
+			}
+		}
+	}
+
+	GIVEN("A const_iterator and iterator pointing to the same position") {
+		FixedSizeCircularBuffer<int, 5> buffer;
+		buffer.push(10);
+		buffer.push(20);
+		buffer.push(30);
+
+		auto it	 = buffer.begin();
+		auto cit = buffer.cbegin();
+
+		WHEN("Comparing iterator and const_iterator") {
+			THEN("Their dereferenced values are equal") {
+				REQUIRE(*it == *cit);
+			}
+
+			THEN("Incrementing both moves them to the next element") {
+				++it;
+				++cit;
+				REQUIRE(*it == *cit);
+			}
+		}
+	}
+
+	GIVEN("Testing operator-> with iterator") {
+		FixedSizeCircularBuffer<std::string, 3> buffer;
+		buffer.push("hello");
+		buffer.push("world");
+
+		auto it = buffer.begin();
+
+		WHEN("Using operator-> to access string methods") {
+			THEN("Can access methods like length()") {
+				REQUIRE(it->length() == 5);
+			}
+
+			++it;
+
+			THEN("Operator-> works on the next element") {
+				REQUIRE(it->substr(1) == "orld");
+			}
+		}
+	}
+
+	GIVEN("Testing iterator arithmetic beyond valid range") {
+		FixedSizeCircularBuffer<int, 5> buffer;
+		buffer.push(1);
+		buffer.push(2);
+		buffer.push(3);
+
+		WHEN("Iterator is incremented beyond end") {
+			auto it = buffer.end();
+			++it;
+
+			THEN("Dereferencing the iterator throws an exception") {
+				REQUIRE_THROWS_AS(*it, std::out_of_range);
+			}
+		}
+
+		WHEN("Iterator is decremented before begin") {
+			auto it = buffer.begin();
+			--it;
+
+			THEN("Dereferencing the iterator throws an exception") {
+				REQUIRE_THROWS_AS(*it, std::out_of_range);
+			}
+		}
+	}
+
+	GIVEN("Testing iterator subtraction") {
+		FixedSizeCircularBuffer<int, 5> buffer;
+		buffer.push(10);
+		buffer.push(20);
+		buffer.push(30);
+		buffer.push(40);
+
+		WHEN("Subtracting two iterators") {
+			auto it1  = buffer.begin() + 1;
+			auto it2  = buffer.begin() + 3;
+			auto diff = it2 - it1;
+
+			THEN("Difference is correct") {
+				REQUIRE(diff == 2);
+			}
+		}
+	}
+}

--- a/lib/mzgl/test/midiCCMessageParserTests.cpp
+++ b/lib/mzgl/test/midiCCMessageParserTests.cpp
@@ -1,0 +1,213 @@
+#include "tests.h"
+#include "midi/MidiMessage.h"
+#include "midi/MidiCCMessageParser.h"
+
+SCENARIO("MidiCCMessageParser converts strings", "[midiccparser]") {
+	for (auto type: {
+			 MidiCCMessageParser::ChangeType::NotApplicable,
+			 MidiCCMessageParser::ChangeType::Positive,
+			 MidiCCMessageParser::ChangeType::Negative,
+			 MidiCCMessageParser::ChangeType::NoChange,
+		 }) {
+		WHEN("Converting " + MidiCCMessageParser::toString(type)) {
+			bool noThrows = true;
+			try {
+				auto str = MidiCCMessageParser::toString(type);
+				REQUIRE_FALSE(str.empty());
+				REQUIRE(MidiCCMessageParser::toType(str) == type);
+			} catch (...) {
+				noThrows = false;
+			}
+			REQUIRE(noThrows);
+		}
+	}
+	REQUIRE_THROWS(MidiCCMessageParser::toType("FOOBAR"));
+}
+
+SCENARIO("MidiCCMessageParser converts to value", "[midiccparser]") {
+	static const std::vector<std::pair<MidiCCMessageParser::ChangeType, int>> types {
+		{MidiCCMessageParser::ChangeType::NotApplicable, 0},
+		{MidiCCMessageParser::ChangeType::Positive, 1},
+		{MidiCCMessageParser::ChangeType::Negative, -1},
+		{MidiCCMessageParser::ChangeType::NoChange, 0},
+	};
+	for (auto [type, value]: types) {
+		WHEN("Converting " + MidiCCMessageParser::toString(type)) {
+			bool noThrows = true;
+			try {
+				REQUIRE(MidiCCMessageParser::toValue(type) == value);
+			} catch (...) {
+				noThrows = false;
+			}
+			REQUIRE(noThrows);
+		}
+	}
+}
+
+SCENARIO("MidiCCMessageParser parses min max 1", "[midiccparser]") {
+	GIVEN("A Parser") {
+		MidiCCMessageParser parser;
+		WHEN("It processes a positive message") {
+			REQUIRE(parser.determineChange(MidiMessage::cc(1, 16, MidiCCModeDetector::getMinMax1Values().first),
+										   MidiCCModeDetector::MidiCCMode::MinMax1)
+					== MidiCCMessageParser::ChangeType::Positive);
+		}
+		WHEN("It processes a negative message") {
+			REQUIRE(parser.determineChange(MidiMessage::cc(1, 16, MidiCCModeDetector::getMinMax1Values().second),
+										   MidiCCModeDetector::MidiCCMode::MinMax1)
+					== MidiCCMessageParser::ChangeType::Negative);
+		}
+	}
+}
+
+SCENARIO("MidiCCMessageParser parses min max 2", "[midiccparser]") {
+	GIVEN("A Parser") {
+		MidiCCMessageParser parser;
+		WHEN("It processes a positive message") {
+			REQUIRE(parser.determineChange(MidiMessage::cc(1, 16, MidiCCModeDetector::getMinMax2Values().first),
+										   MidiCCModeDetector::MidiCCMode::MinMax2)
+					== MidiCCMessageParser::ChangeType::Positive);
+		}
+		WHEN("It processes a negative message") {
+			REQUIRE(parser.determineChange(MidiMessage::cc(1, 16, MidiCCModeDetector::getMinMax2Values().second),
+										   MidiCCModeDetector::MidiCCMode::MinMax2)
+					== MidiCCMessageParser::ChangeType::Negative);
+		}
+	}
+}
+
+SCENARIO("MidiCCMessageParser parses binary offset", "[midiccparser]") {
+	GIVEN("A Parser") {
+		MidiCCMessageParser parser;
+		WHEN("It processes a positive message") {
+			REQUIRE(
+				parser.determineChange(MidiMessage::cc(1, 16, MidiCCModeDetector::getRelativeBinaryRange().first),
+									   MidiCCModeDetector::MidiCCMode::RelativeBinaryOffset)
+				== MidiCCMessageParser::ChangeType::Positive);
+		}
+		WHEN("It processes a negative message") {
+			REQUIRE(
+				parser.determineChange(MidiMessage::cc(1, 16, MidiCCModeDetector::getRelativeBinaryRange().second),
+									   MidiCCModeDetector::MidiCCMode::RelativeBinaryOffset)
+				== MidiCCMessageParser::ChangeType::Negative);
+		}
+		WHEN("It processes a zero message") {
+			REQUIRE(parser.determineChange(MidiMessage::cc(1, 16, 64),
+										   MidiCCModeDetector::MidiCCMode::RelativeBinaryOffset)
+					== MidiCCMessageParser::ChangeType::NoChange);
+		}
+	}
+}
+
+SCENARIO("MidiCCMessageParser parses Arturia relative 1", "[midiccparser]") {
+	GIVEN("A Parser") {
+		MidiCCMessageParser parser;
+		WHEN("It processes a positive message") {
+			REQUIRE(parser.determineChange(
+						MidiMessage::cc(1, 16, MidiCCModeDetector::getArturiaRelative1Range().second),
+						MidiCCModeDetector::MidiCCMode::ArturiaRelative1)
+					== MidiCCMessageParser::ChangeType::Positive);
+		}
+		WHEN("It processes a negative message") {
+			REQUIRE(parser.determineChange(
+						MidiMessage::cc(1, 16, MidiCCModeDetector::getArturiaRelative1Range().first),
+						MidiCCModeDetector::MidiCCMode::ArturiaRelative1)
+					== MidiCCMessageParser::ChangeType::Negative);
+		}
+		WHEN("It processes a zero message") {
+			REQUIRE(
+				parser.determineChange(MidiMessage::cc(1, 16, 0), MidiCCModeDetector::MidiCCMode::ArturiaRelative1)
+				== MidiCCMessageParser::ChangeType::NoChange);
+		}
+	}
+}
+
+SCENARIO("MidiCCMessageParser parses Arturia relative 2", "[midiccparser]") {
+	GIVEN("A Parser") {
+		MidiCCMessageParser parser;
+		WHEN("It processes a positive message") {
+			REQUIRE(
+				parser.determineChange(MidiMessage::cc(1, 16, 3), MidiCCModeDetector::MidiCCMode::ArturiaRelative2)
+				== MidiCCMessageParser::ChangeType::Positive);
+		}
+		WHEN("It processes a negative message") {
+			REQUIRE(parser.determineChange(MidiMessage::cc(1, 16, 125),
+										   MidiCCModeDetector::MidiCCMode::ArturiaRelative2)
+					== MidiCCMessageParser::ChangeType::Negative);
+		}
+		WHEN("It processes a zero message") {
+			REQUIRE(
+				parser.determineChange(MidiMessage::cc(1, 16, 0), MidiCCModeDetector::MidiCCMode::ArturiaRelative2)
+				== MidiCCMessageParser::ChangeType::NoChange);
+		}
+	}
+}
+
+SCENARIO("MidiCCMessageParser parses Arturia relative 3", "[midiccparser]") {
+	GIVEN("A Parser") {
+		MidiCCMessageParser parser;
+		WHEN("It processes a positive message") {
+			REQUIRE(parser.determineChange(MidiMessage::cc(1, 16, 19),
+										   MidiCCModeDetector::MidiCCMode::ArturiaRelative3)
+					== MidiCCMessageParser::ChangeType::Positive);
+		}
+		WHEN("It processes a negative message") {
+			REQUIRE(parser.determineChange(MidiMessage::cc(1, 16, 13),
+										   MidiCCModeDetector::MidiCCMode::ArturiaRelative3)
+					== MidiCCMessageParser::ChangeType::Negative);
+		}
+		WHEN("It processes a zero message") {
+			REQUIRE(
+				parser.determineChange(MidiMessage::cc(1, 16, 0), MidiCCModeDetector::MidiCCMode::ArturiaRelative3)
+				== MidiCCMessageParser::ChangeType::NoChange);
+		}
+	}
+}
+
+SCENARIO("MidiCCMessageParser parses 2s complement", "[midiccparser]") {
+	GIVEN("A Parser") {
+		MidiCCMessageParser parser;
+		WHEN("It processes a positive message") {
+			REQUIRE(parser.determineChange(MidiMessage::cc(1, 16, 0x05),
+										   MidiCCModeDetector::MidiCCMode::TwosComplement)
+					== MidiCCMessageParser::ChangeType::Positive);
+		}
+		WHEN("It processes a negative message") {
+			REQUIRE(parser.determineChange(MidiMessage::cc(1, 16, 0x7B),
+										   MidiCCModeDetector::MidiCCMode::TwosComplement)
+					== MidiCCMessageParser::ChangeType::Negative);
+		}
+	}
+}
+
+SCENARIO("MidiCCMessageParser parses signed bit 1", "[midiccparser]") {
+	GIVEN("A Parser") {
+		MidiCCMessageParser parser;
+		WHEN("It processes a positive message") {
+			REQUIRE(
+				parser.determineChange(MidiMessage::cc(1, 16, 0x05), MidiCCModeDetector::MidiCCMode::SignedBit1)
+				== MidiCCMessageParser::ChangeType::Positive);
+		}
+		WHEN("It processes a negative message") {
+			REQUIRE(
+				parser.determineChange(MidiMessage::cc(1, 16, 0x45), MidiCCModeDetector::MidiCCMode::SignedBit1)
+				== MidiCCMessageParser::ChangeType::Negative);
+		}
+	}
+}
+
+SCENARIO("MidiCCMessageParser parses signed bit 2", "[midiccparser]") {
+	GIVEN("A Parser") {
+		MidiCCMessageParser parser;
+		WHEN("It processes a positive message") {
+			REQUIRE(
+				parser.determineChange(MidiMessage::cc(1, 16, 0x45), MidiCCModeDetector::MidiCCMode::SignedBit2)
+				== MidiCCMessageParser::ChangeType::Positive);
+		}
+		WHEN("It processes a negative message") {
+			REQUIRE(
+				parser.determineChange(MidiMessage::cc(1, 16, 0x05), MidiCCModeDetector::MidiCCMode::SignedBit2)
+				== MidiCCMessageParser::ChangeType::Negative);
+		}
+	}
+}

--- a/lib/mzgl/test/midiCCModeDetectorTests.cpp
+++ b/lib/mzgl/test/midiCCModeDetectorTests.cpp
@@ -1,0 +1,205 @@
+#include "tests.h"
+#include "midi/MidiMessage.h"
+#include "midi/MidiCCModeDetector.h"
+
+SCENARIO("MidiCCModeDetector converts strings", "[midiccmode]") {
+	for (auto mode: {
+			 MidiCCModeDetector::MidiCCMode::Unknown,
+			 MidiCCModeDetector::MidiCCMode::Absolute,
+			 MidiCCModeDetector::MidiCCMode::TwosComplement,
+			 MidiCCModeDetector::MidiCCMode::RelativeBinaryOffset,
+			 MidiCCModeDetector::MidiCCMode::SignedBit1,
+			 MidiCCModeDetector::MidiCCMode::SignedBit2,
+			 MidiCCModeDetector::MidiCCMode::ArturiaRelative1,
+			 MidiCCModeDetector::MidiCCMode::ArturiaRelative2,
+			 MidiCCModeDetector::MidiCCMode::ArturiaRelative3,
+		 }) {
+		WHEN("Converting " + MidiCCModeDetector::toString(mode)) {
+			bool noThrows = true;
+			try {
+				auto str = MidiCCModeDetector::toString(mode);
+				REQUIRE_FALSE(str.empty());
+				REQUIRE(MidiCCModeDetector::toMode(str) == mode);
+			} catch (...) {
+				noThrows = false;
+			}
+			REQUIRE(noThrows);
+		}
+	}
+	REQUIRE_THROWS(MidiCCModeDetector::toMode("FOOBAR"));
+}
+
+SCENARIO("MidiCCModeDetector processes MIDI CC messages and detects absolute mode", "[midiccmode]") {
+	GIVEN("A MidiCCModeDetector") {
+		MidiCCModeDetector detector;
+		WHEN("Processing a series of absolute CC messages") {
+			static constexpr auto midiCCChannel = 1;
+			static constexpr auto midiCCIndex	= 16;
+			for (int value = 0; value < 127; ++value) {
+				detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, value));
+			}
+			THEN("It should detect the mode as Absolute") {
+				auto mode = detector.getDetectedMode(midiCCIndex);
+				REQUIRE(mode == MidiCCModeDetector::MidiCCMode::Absolute);
+			}
+		}
+	}
+}
+
+SCENARIO("MidiCCModeDetector processes MIDI CC messages and detects Arturia relative 1", "[midiccmode]") {
+	GIVEN("A MidiCCModeDetector") {
+		MidiCCModeDetector detector;
+		WHEN("Processing a series of absolute CC messages") {
+			static constexpr auto midiCCChannel = 1;
+			static constexpr auto midiCCIndex	= 16;
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 61));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 0));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 63));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 0));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 67));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 0));
+			THEN("It should detect the mode as Arturia relative 1") {
+				auto mode = detector.getDetectedMode(midiCCIndex);
+				REQUIRE(mode == MidiCCModeDetector::MidiCCMode::ArturiaRelative1);
+			}
+		}
+	}
+}
+
+SCENARIO("MidiCCModeDetector processes MIDI CC messages and detects Arturia relative 2", "[midiccmode]") {
+	GIVEN("A MidiCCModeDetector") {
+		MidiCCModeDetector detector;
+		WHEN("Processing a series of absolute CC messages") {
+			static constexpr auto midiCCChannel = 1;
+			static constexpr auto midiCCIndex	= 16;
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 1));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 0));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 2));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 0));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 3));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 0));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 125));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 0));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 126));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 0));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 127));
+			THEN("It should detect the mode as Arturia relative 2") {
+				auto mode = detector.getDetectedMode(midiCCIndex);
+				REQUIRE(mode == MidiCCModeDetector::MidiCCMode::ArturiaRelative2);
+			}
+		}
+	}
+}
+
+SCENARIO("MidiCCModeDetector processes MIDI CC messages and detects Arturia relative 3", "[midiccmode]") {
+	GIVEN("A MidiCCModeDetector") {
+		MidiCCModeDetector detector;
+		WHEN("Processing a series of absolute CC messages") {
+			static constexpr auto midiCCChannel = 1;
+			static constexpr auto midiCCIndex	= 16;
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 15));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 0));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 14));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 0));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 13));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 0));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 19));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 0));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 17));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 0));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 18));
+			THEN("It should detect the mode as Arturia relative 3") {
+				auto mode = detector.getDetectedMode(midiCCIndex);
+				REQUIRE(mode == MidiCCModeDetector::MidiCCMode::ArturiaRelative3);
+			}
+		}
+	}
+}
+
+SCENARIO("MidiCCModeDetector processes MIDI CC messages and detects Relative Binary Offset", "[midiccmode]") {
+	GIVEN("A MidiCCModeDetector") {
+		MidiCCModeDetector detector;
+		WHEN("Processing a series of absolute CC messages") {
+			static constexpr auto midiCCChannel = 1;
+			static constexpr auto midiCCIndex	= 16;
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 63));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 64));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 65));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 65));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 65));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 65));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 65));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 63));
+			THEN("It should detect the mode as Relative Binary Offset") {
+				auto mode = detector.getDetectedMode(midiCCIndex);
+				REQUIRE(mode == MidiCCModeDetector::MidiCCMode::RelativeBinaryOffset);
+			}
+		}
+	}
+}
+
+SCENARIO("MidiCCModeDetector processes MIDI CC messages and detects Min Max 1", "[midiccmode]") {
+	GIVEN("A MidiCCModeDetector") {
+		MidiCCModeDetector detector;
+		WHEN("Processing a series of absolute CC messages") {
+			static constexpr auto midiCCChannel = 1;
+			static constexpr auto midiCCIndex	= 16;
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 1));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 127));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 127));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 127));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 1));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 1));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 127));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 127));
+			THEN("It should detect the mode as Min Max 1") {
+				auto mode = detector.getDetectedMode(midiCCIndex);
+				REQUIRE(mode == MidiCCModeDetector::MidiCCMode::MinMax1);
+			}
+		}
+	}
+}
+
+SCENARIO("MidiCCModeDetector processes MIDI CC messages and detects Min Max 2", "[midiccmode]") {
+	GIVEN("A MidiCCModeDetector") {
+		MidiCCModeDetector detector;
+		WHEN("Processing a series of absolute CC messages") {
+			static constexpr auto midiCCChannel = 1;
+			static constexpr auto midiCCIndex	= 16;
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 63));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 65));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 65));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 63));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 65));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 63));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 63));
+			detector.process(MidiMessage::cc(midiCCChannel, midiCCIndex, 65));
+			THEN("It should detect the mode as Min Max 2") {
+				auto mode = detector.getDetectedMode(midiCCIndex);
+				REQUIRE(mode == MidiCCModeDetector::MidiCCMode::MinMax2);
+			}
+		}
+	}
+}
+
+SCENARIO("MidiCCModeDetector processor handles errors", "[midiccmode]") {
+	GIVEN("A detector") {
+		MidiCCModeDetector detector;
+
+		WHEN("Requesting the detected mode for an invalid CC index") {
+			THEN("It should throw an out_of_range exception") {
+				REQUIRE_THROWS_AS(detector.getDetectedMode(128), std::out_of_range);
+			}
+		}
+
+		WHEN("Processing non-CC MIDI messages") {
+			auto msg = MidiMessage::noteOn(1, 60, 100);
+			detector.process(msg);
+
+			THEN("It should ignore them and maintain default modes") {
+				auto mode = detector.getDetectedMode(0);
+				REQUIRE(mode == MidiCCModeDetector::MidiCCMode::Unknown);
+			}
+		}
+	}
+}

--- a/lib/mzgl/util/FixedSizeCircularBuffer.h
+++ b/lib/mzgl/util/FixedSizeCircularBuffer.h
@@ -1,0 +1,191 @@
+#pragma once
+#include <array>
+#include <cstddef>
+
+template <typename T, size_t N>
+class FixedSizeCircularBuffer {
+public:
+	FixedSizeCircularBuffer()
+		: headPosition(0)
+		, currentSize(0) {}
+
+	void push(const T &item) {
+		buffer[headPosition] = item;
+		headPosition		 = (headPosition + 1) % N;
+		if (currentSize < N) {
+			++currentSize;
+		}
+	}
+
+	T &operator[](size_t index) {
+		if (index >= currentSize) {
+			throw std::out_of_range("Index out of range");
+		}
+		size_t idx = (headPosition + N - currentSize + index) % N;
+		return buffer[idx];
+	}
+
+	const T &operator[](size_t index) const {
+		if (index >= currentSize) {
+			throw std::out_of_range("Index out of range");
+		}
+		size_t idx = (headPosition + N - currentSize + index) % N;
+		return buffer[idx];
+	}
+
+	[[nodiscard]] size_t size() const { return currentSize; }
+	[[nodiscard]] bool empty() const { return size() == 0; }
+
+	void clear() {
+		headPosition = 0;
+		currentSize	 = 0;
+	}
+
+	class iterator {
+	public:
+		using iterator_category = std::random_access_iterator_tag;
+		using value_type		= T;
+		using difference_type	= std::ptrdiff_t;
+		using pointer			= T *;
+		using reference			= T &;
+
+		iterator(FixedSizeCircularBuffer *_buffer, std::size_t _index)
+			: buffer(_buffer)
+			, index(_index) {}
+
+		reference operator*() const { return (*buffer)[index]; }
+		pointer operator->() const { return &(*buffer)[index]; }
+
+		iterator &operator++() {
+			++index;
+			return *this;
+		}
+
+		iterator operator++(int) {
+			iterator tmp = *this;
+			++index;
+			return tmp;
+		}
+
+		iterator &operator--() {
+			--index;
+			return *this;
+		}
+
+		iterator operator--(int) {
+			iterator tmp = *this;
+			--index;
+			return tmp;
+		}
+
+		iterator operator+(difference_type n) const { return iterator(buffer, index + n); }
+		iterator operator-(difference_type n) const { return iterator(buffer, index - n); }
+
+		difference_type operator-(const iterator &other) const {
+			return static_cast<difference_type>(index) - static_cast<difference_type>(other.index);
+		}
+
+		iterator &operator+=(difference_type n) {
+			index += n;
+			return *this;
+		}
+
+		iterator &operator-=(difference_type n) {
+			index -= n;
+			return *this;
+		}
+
+		bool operator==(const iterator &other) const { return buffer == other.buffer && index == other.index; }
+		bool operator!=(const iterator &other) const { return !(*this == other); }
+		bool operator<(const iterator &other) const { return index < other.index; }
+		bool operator>(const iterator &other) const { return index > other.index; }
+		bool operator<=(const iterator &other) const { return index <= other.index; }
+		bool operator>=(const iterator &other) const { return index >= other.index; }
+
+	private:
+		FixedSizeCircularBuffer *buffer;
+		std::size_t index;
+	};
+
+	class const_iterator {
+	public:
+		using iterator_category = std::random_access_iterator_tag;
+		using value_type		= const T;
+		using difference_type	= std::ptrdiff_t;
+		using pointer			= const T *;
+		using reference			= const T &;
+
+		const_iterator(const FixedSizeCircularBuffer *_buffer, std::size_t _index)
+			: buffer(_buffer)
+			, index(_index) {}
+
+		reference operator*() const { return (*buffer)[index]; }
+		pointer operator->() const { return &(*buffer)[index]; }
+
+		const_iterator &operator++() {
+			++index;
+			return *this;
+		}
+
+		const_iterator operator++(int) {
+			const_iterator tmp = *this;
+			++index;
+			return tmp;
+		}
+
+		const_iterator &operator--() {
+			--index;
+			return *this;
+		}
+
+		const_iterator operator--(int) {
+			const_iterator tmp = *this;
+			--index;
+			return tmp;
+		}
+
+		const_iterator operator+(difference_type n) const { return const_iterator(buffer, index + n); }
+		const_iterator operator-(difference_type n) const { return const_iterator(buffer, index - n); }
+
+		difference_type operator-(const const_iterator &other) const {
+			return static_cast<difference_type>(index) - static_cast<difference_type>(other.index);
+		}
+
+		bool operator==(const const_iterator &other) const {
+			return buffer == other.buffer && index == other.index;
+		}
+
+		const_iterator &operator+=(difference_type n) {
+			index += n;
+			return *this;
+		}
+
+		const_iterator &operator-=(difference_type n) {
+			index -= n;
+			return *this;
+		}
+
+		bool operator!=(const const_iterator &other) const { return !(*this == other); }
+		bool operator<(const const_iterator &other) const { return index < other.index; }
+		bool operator>(const const_iterator &other) const { return index > other.index; }
+		bool operator<=(const const_iterator &other) const { return index <= other.index; }
+		bool operator>=(const const_iterator &other) const { return index >= other.index; }
+
+	private:
+		const FixedSizeCircularBuffer *buffer;
+		std::size_t index;
+	};
+
+	const_iterator cbegin() const { return const_iterator(this, 0); }
+	const_iterator begin() const { return const_iterator(this, 0); }
+	iterator begin() { return iterator(this, 0); }
+
+	const_iterator cend() const { return const_iterator(this, currentSize); }
+	const_iterator end() const { return const_iterator(this, currentSize); }
+	iterator end() { return iterator(this, currentSize); }
+
+private:
+	std::array<T, N> buffer;
+	size_t headPosition;
+	size_t currentSize;
+};


### PR DESCRIPTION
Okay... so... it turns out that relative midi is a *really* manufacturer specific thing, and in some cases can be detected and in others its not automatically detectable, because it shares the same range as the normal "absolute" midi CC values. 
Here is how I approached this:
* First I did a lot of research (including getting CGPT to dream up a bunch of worthless information!). Most of the info ended up coming from manuals for devices.
* I did this fully TDD, because that was the simplest way to handle it. What ive done is to split the code in to 2 parts - detection and then processing.
* The detector needed a FIFO that didnt allocate. I couldn't find one, so I ended up writing my own - let me know if there was already one in there. This one has tests :P 
* The detector gets given a bunch of midi messages. For each midi CC index it can try to detect what encoding the CC is using. Unfortunately, some cant be detected and the user will have to define the mode they want. All the modes I could find are defined in the detector, and I tried to include as many links etc as possible 
* Once the mode is defined, the messages can be processed. Here you get an enum back that is either "do nothing", "inc", "dec" - this can then be applied however the end result is required. 
In theory we can add to this in the future fairly easily if we come across other device encodings. The set that ive got should cover Ableton, Cubase, Arturia and Akai for sure, plus a bunch of small manufacturers... 
Ive added comments inline where I felt the coded needed explanation