### PR TITLE
Supress warnings in 3rd party code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,3 +472,5 @@ endif()
 if(NOT WIN32)
   add_compile_options(-fdiagnostics-color=always)
 endif()
+
+mzgl_supress_warnings()

--- a/cmake/mzgl.cmake
+++ b/cmake/mzgl.cmake
@@ -5,6 +5,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/log-saver.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/warning-saver.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/package-manager.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/dependencies.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/warnings.cmake)
 
 mzgl_detect_cpm_root_dir()
 mzgl_detect_cpm_sub_dir()

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -1,0 +1,22 @@
+function(mzgl_supress_target_warnings TARGET)
+  mzgl_print_in_green("Supressing warnings in ${TARGET}")
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang")
+    target_compile_options("${TARGET}" PRIVATE -w)
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_compile_options("${TARGET}" PRIVATE -w)
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options("${TARGET}" PRIVATE /w)
+  else()
+    message(WARNING "Unknown compiler. Warnings suppression not applied.")
+  endif()
+endfunction(mzgl_supress_target_warnings)
+
+function(mzgl_supress_warnings)
+  mzgl_supress_target_warnings(ZipFile)
+  mzgl_supress_target_warnings(staticZipper)
+  if(NOT ANDROID
+     AND NOT WIN32
+     AND NOT IOS)
+    mzgl_supress_target_warnings(PortAudio)
+  endif()
+endfunction()


### PR DESCRIPTION
Warnings in 3rd party code (that we either wont or cant fix) are flooding the build logs. This gives us a flexible way (with notifications) to remove them.