### PR TITLE
Add test function for ios version

### DIFF
--- a/lib/mzgl/mzgl_platform.h
+++ b/lib/mzgl/mzgl_platform.h
@@ -4,6 +4,11 @@
 #	include <TargetConditionals.h>
 #	if TARGET_OS_IOS
 #		define MZGL_IOS 1
+#		if __has_builtin(__builtin_available)
+#			define IS_ON_IOS_VERSION_OR_LATER(version) __builtin_available(iOS version, *)
+#		else
+#			define IS_ON_IOS_VERSION_OR_LATER(version) false
+#		endif
 #	else
 #		define MZGL_MAC 1
 #	endif


### PR DESCRIPTION
This adds a macro that will test for iOS versions. Note that it has to be used like this:

```
#if MZGL_IOS
	if (IS_ON_IOS_VERSION_OR_LATER(14.0)) {
		return true;
	}
	return false;
#endif
```

using it like this:
```
return IS_ON_IOS_VERSION_OR_LATER(14.0);
```
will not work