### PR TITLE
Make sure of Graphics lifecycle

### DIFF
--- a/lib/mzgl/app/apple/AUv3/AudioUnitViewController.mm
+++ b/lib/mzgl/app/apple/AUv3/AudioUnitViewController.mm
@@ -34,11 +34,11 @@ using namespace std;
 	MZGLView *glView;
 	std::shared_ptr<EventDispatcher> eventDispatcher;
 #endif
-	Graphics g;
 	MZGLEffectAU *audioUnit;
 
 	std::shared_ptr<Plugin> plugin;
 	std::shared_ptr<PluginEditor> app;
+	std::shared_ptr<Graphics> g;
 }
 
 - (id)init {
@@ -49,10 +49,18 @@ using namespace std;
 	return self;
 }
 
+- (void)dealloc {
+	NSLog(@"dealloc AudioUnitViewController");
+	app.reset();
+	plugin.reset();
+	g.reset();
+}
+
 - (void)setup {
 	app		  = nullptr;
 	plugin	  = nullptr;
 	audioUnit = nil;
+	g		  = nullptr;
 	//#if !TARGET_OS_IOS
 	//        auto &g = appHolder.g;
 	//        appHolder.app = std::shared_ptr<App>(instantiateApp(g));
@@ -143,10 +151,11 @@ using namespace std;
 
 - (void)viewWillAppear:(BOOL)animated {
 	if (app == nullptr) {
+		g = std::make_shared<Graphics>();
 		plugin = [self getPlugin];
-		app	   = instantiatePluginEditor(g, plugin);
+		app	   = instantiatePluginEditor(*g, plugin);
 #if MZGL_IOS
-		vc					= [[MZGLKitViewController alloc] initWithApp:app];
+		vc					= [[MZGLKitViewController alloc] initWithApp:app andGraphics:g];
 		app->viewController = (__bridge void *) self;
 
 		glView = (MZGLKitView *) vc.view;
@@ -156,8 +165,8 @@ using namespace std;
 #endif
 		glView.frame = self.view.frame;
 #if !MZGL_IOS
-		g.width	 = self.view.frame.size.width * 2;
-		g.height = self.view.frame.size.height * 2;
+		g->width	 = self.view.frame.size.width * 2;
+		g->height = self.view.frame.size.height * 2;
 		eventDispatcher->resized();
 #endif
 		[self addGLView];

--- a/lib/mzgl/app/ios/MZGLKitView.h
+++ b/lib/mzgl/app/ios/MZGLKitView.h
@@ -11,10 +11,11 @@
 #include "App.h"
 
 class EventDispatcher;
+class Graphics;
 
 @interface MZGLKitView : GLKView
 - (std::shared_ptr<App>)getApp;
-- (id)initWithApp:(std::shared_ptr<App>)_app;
+- (id)initWithApp:(std::shared_ptr<App>)_app andGraphics:(std::shared_ptr<Graphics>)_graphics;
 - (std::shared_ptr<EventDispatcher>)getEventDispatcher;
 - (BOOL)handleNormalOpen:(NSURL *)url;
 - (void) deleteCppObjects;

--- a/lib/mzgl/app/ios/MZGLKitView.mm
+++ b/lib/mzgl/app/ios/MZGLKitView.mm
@@ -19,6 +19,7 @@ API_AVAILABLE(ios(11)) @interface MZGLKitView(DragDropExtensions)<UIDropInteract
 @implementation MZGLKitView {
 	std::shared_ptr<App> app;
 	std::shared_ptr<EventDispatcher> eventDispatcher;
+	std::shared_ptr<Graphics> graphics;
 
 	NSMutableDictionary *activeTouches;
 	bool firstFrame;
@@ -27,6 +28,7 @@ API_AVAILABLE(ios(11)) @interface MZGLKitView(DragDropExtensions)<UIDropInteract
 - (void) deleteCppObjects {
 	app = nullptr;
 	eventDispatcher = nullptr;
+	graphics = nullptr;
 }
 
 - (std::shared_ptr<App>)getApp {
@@ -37,10 +39,11 @@ API_AVAILABLE(ios(11)) @interface MZGLKitView(DragDropExtensions)<UIDropInteract
 	NSLog(@"Tearing down MZGLKitView");
 }
 
-- (id)initWithApp:(std::shared_ptr<App>)_app {
+- (id)initWithApp:(std::shared_ptr<App>)_app andGraphics:(std::shared_ptr<Graphics>)_graphics {
 	self = [super init];
 	if (self != nil) {
 		app = _app;
+		graphics = _graphics;
 
 		eventDispatcher = std::make_shared<EventDispatcher>(app);
 

--- a/lib/mzgl/app/ios/MZGLKitViewController.h
+++ b/lib/mzgl/app/ios/MZGLKitViewController.h
@@ -13,7 +13,7 @@
 #endif
 #import "MZGLKitView.h"
 class App;
-
+class Graphics;
 class EventDispatcher;
 @interface MZGLKitViewController
 	: GLKViewController
@@ -24,7 +24,7 @@ class EventDispatcher;
 	  <GLKViewControllerDelegate>
 #endif
 
-- (id)initWithApp:(std::shared_ptr<App>)app;
+- (id)initWithApp:(std::shared_ptr<App>)app andGraphics:(std::shared_ptr<Graphics>)_graphics;
 - (std::shared_ptr<EventDispatcher>)getEventDispatcher;
 //- (void) openURLWhenLoadedAndDeleteFile: (NSString*) urlToOpen;
 - (MZGLKitView *)getView;

--- a/lib/mzgl/app/ios/MZGLKitViewController.mm
+++ b/lib/mzgl/app/ios/MZGLKitViewController.mm
@@ -31,13 +31,13 @@
 //     apparently. Bit of a hack but it works.
 
 EAGLContext *context = nil;
-- (id)initWithApp:(std::shared_ptr<App>)_app {
+- (id)initWithApp:(std::shared_ptr<App>)_app andGraphics:(std::shared_ptr<Graphics>)_graphics {
 	self = [super init];
 	if (self != nil) {
 		currentlyPaused				  = YES;
 		self.delegate				  = self;
 		self.preferredFramesPerSecond = 60.f;
-		mzView						  = [[MZGLKitView alloc] initWithApp:_app];
+		mzView						  = [[MZGLKitView alloc] initWithApp:_app andGraphics:_graphics];
 		self.view					  = mzView;
 		GLKView *v					  = self.view;
 

--- a/lib/mzgl/app/ios/iOSAppDelegate.mm
+++ b/lib/mzgl/app/ios/iOSAppDelegate.mm
@@ -29,7 +29,7 @@ void quitApplication() {
 @interface iOSAppDelegate () {
 	std::shared_ptr<App> app;
 	std::shared_ptr<Plugin> plugin;
-	Graphics g;
+	std::shared_ptr<Graphics> g;
 	MZGLKitViewController *mzViewController;
 }
 @end
@@ -120,18 +120,19 @@ public:
 	self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
 
 	try {
+		g = std::make_shared<Graphics>();
 		if (isPlugin()) {
 			plugin = instantiatePlugin();
-			app	   = instantiatePluginEditor(g, plugin);
+			app	   = instantiatePluginEditor(*g, plugin);
 		} else {
-			app = instantiateApp(g);
+			app = instantiateApp(*g);
 		}
 	} catch (std::exception &e) {
 		writeStringToFile("instantiateAppError.txt", e.what());
-		app = std::make_shared<ErrorApp>(g, e.what());
+		app = std::make_shared<ErrorApp>(*g, e.what());
 	}
 
-	mzViewController		  = [[MZGLKitViewController alloc] initWithApp:app];
+	mzViewController		  = [[MZGLKitViewController alloc] initWithApp:app andGraphics:g];
 	window.rootViewController = mzViewController;
 	app->viewController		  = (__bridge void *) mzViewController;
 	app->windowHandle		  = (__bridge void *) window;
@@ -191,6 +192,7 @@ public:
 
 	// destroy plugin last! it must live longer than app.
 	plugin = nullptr;
+	g = nullptr;
 }
 
 @end

--- a/lib/mzgl/ui/Layer.cpp
+++ b/lib/mzgl/ui/Layer.cpp
@@ -442,13 +442,14 @@ void Layer::transferFocus(Layer *fromLayer, Layer *toLayer) {
 }
 
 void Layer::clear() {
-	for (auto *ch: children) {
-		for (auto it = g.focusedLayers.begin(); it != g.focusedLayers.end();) {
-			if ((*it).second == ch) {
+	if (!g.focusedLayers.empty()) {
+		for (auto *ch: children) {
+			auto it = std::find_if(g.focusedLayers.begin(), g.focusedLayers.end(), [ch](auto && focus){
+				return focus.second == ch;
+			});
+			if (it != g.focusedLayers.end()) {
 				mzAssert(false, "Can't delete a layer whilst there is an interaction going on with it!");
-				g.focusedLayers.erase(it++);
-			} else {
-				it++;
+				g.focusedLayers.erase(it);
 			}
 		}
 	}


### PR DESCRIPTION
The root cause was that because Graphics was created as a member on the stack of an objective C class, but then passed to a heap allocated class, it was being deleted before the app. Hence the layer when it came to check the focussed layers in clear on the root layer would fail.
What I did to fix this is:
* Make graphics a std::shared_ptr everywhere it was being used
* Pass it everywhere that the app goes
* Make sure it is reset after the app and the plugin editor.
This fixes the crash and asan no longer complains
Best way that I found to reproduce the issue was to put Koala in aum and then long press on the plugin and choose reload. This would cause the crash every time