### PR TITLE
Adds an undo gesture where all actions are applied, but it undoes / r…

### DIFF
--- a/lib/mzgl/util/UndoManager.h
+++ b/lib/mzgl/util/UndoManager.h
@@ -56,6 +56,9 @@ public:
 	void beginGroup();
 	void endGroup();
 
+	void beginGesture();
+	void endGesture();
+
 	bool undo();
 	bool redo();
 
@@ -66,6 +69,7 @@ public:
 
 private:
 	UndoableRef undoGroup = nullptr;
+	UndoableRef gestureGroup = nullptr;
 	std::deque<UndoableRef>::iterator undoPos;
 	std::deque<UndoableRef> undoStack;
 };


### PR DESCRIPTION
I needed a way to group actions, but with the individual commits still happening (the undo/redo Group only applies the commits in a chunk when you end the group).
Ive added undo/redo Gesture, which applies the commits atomically, but allows us to undo / redo them all together later on! Works well for the auto code I was working on 