### PR TITLE
Fix a deadlock in threadpool

### DIFF
--- a/lib/mzgl/util/ThreadPool.h
+++ b/lib/mzgl/util/ThreadPool.h
@@ -84,11 +84,17 @@ inline ThreadPool::~ThreadPool() {
 }
 
 inline void ThreadPool::stop() {
-	if (stopped.load()) {
-		return;
+	{
+		// Set `stopped` under queue_mutex so it's serialized with the worker's
+		// predicate check inside condition.wait(). Without the lock there is a
+		// window between a worker evaluating the predicate and entering wait()
+		// where notify_all() reaches no one and the worker sleeps forever.
+		std::unique_lock<std::mutex> lock(queue_mutex);
+		if (stopped.load()) {
+			return;
+		}
+		stopped.store(true);
 	}
-
-	stopped.store(true);
 	condition.notify_all();
 
 	for (std::thread &worker: workers) {


### PR DESCRIPTION
Threadpool has a deadlock in its join:

stop() was setting stopped = true and calling condition.notify_all() without holding queue_mutex. The worker's condition.wait(lock, predicate) has a tiny window between evaluating the predicate (sees not-stopped, no tasks) and actually entering the sleep. If stop() fires its notify_all() in that window, the notification reaches a thread that isn't asleep yet — it's lost — and the worker then sleeps forever. stop() blocks on join().

The fix sets stopped under queue_mutex, which serializes it with the worker's predicate-check-and-wait, so the worker either sees stopped==true before waiting or is guaranteed asleep when notify_all() fires: