### PR TITLE
Replace per-frame layer tree traversal with ScopedUpdater

### DIFF
--- a/lib/mzgl/gl/Graphics.cpp
+++ b/lib/mzgl/gl/Graphics.cpp
@@ -16,6 +16,7 @@
 #include "MitredLine.h"
 #include "Drawer.h"
 #include <utility>
+#include <algorithm>
 #include "GraphicsAPI.h"
 
 #include <array>
@@ -569,6 +570,34 @@ Graphics::Graphics() {
 #else
 	api = std::make_unique<OpenGLAPI>(*this);
 #endif
+}
+
+void Graphics::registerUpdater(ScopedUpdater *updater) {
+	updaters.push_back(updater);
+}
+
+void Graphics::unregisterUpdater(ScopedUpdater *updater) {
+	auto it = std::find(updaters.begin(), updaters.end(), updater);
+	if (it == updaters.end()) return;
+	if (iteratingUpdaters) {
+		// can't erase mid-iteration, runRegisteredUpdaters() sweeps nulls
+		*it = nullptr;
+	} else {
+		updaters.erase(it);
+	}
+}
+
+void Graphics::runRegisteredUpdaters() {
+	iteratingUpdaters = true;
+	// index loop because an updater can create new ones,
+	// which are appended and run this same frame
+	for (size_t i = 0; i < updaters.size(); i++) {
+		if (updaters[i] != nullptr) {
+			updaters[i]->fn();
+		}
+	}
+	iteratingUpdaters = false;
+	updaters.erase(std::remove(updaters.begin(), updaters.end(), nullptr), updaters.end());
 }
 
 int32_t Graphics::getDefaultFrameBufferId() {

--- a/lib/mzgl/gl/Graphics.h
+++ b/lib/mzgl/gl/Graphics.h
@@ -50,6 +50,7 @@ class ScopedAlphaBlend;
 class ScopedNoFill;
 class ScopedTranslate;
 class ScopedTransform;
+class ScopedUpdater;
 class GraphicsAPI;
 class OpenGLAPI;
 class Graphics {
@@ -215,6 +216,13 @@ public:
 
 	Layer *keyboardFocusedLayer = nullptr;
 
+	// anything that wants a callback once per frame holds a ScopedUpdater
+	// (see bottom of this file) - this replaces walking the whole layer
+	// tree every frame. Needs to be here so it's not static.
+	void registerUpdater(ScopedUpdater *updater);
+	void unregisterUpdater(ScopedUpdater *updater);
+	void runRegisteredUpdaters();
+
 	// OpenGL only
 	int32_t getDefaultFrameBufferId();
 	GraphicsAPI &getAPI() { return *api; }
@@ -222,6 +230,11 @@ public:
 	VboRef drawerVbo;
 
 private:
+	// see registerUpdater() - entries are nulled rather than erased
+	// while runRegisteredUpdaters() is iterating, then swept afterwards.
+	std::vector<ScopedUpdater *> updaters;
+	bool iteratingUpdaters = false;
+
 	BlendMode blendMode = BlendMode::Alpha;
 
 	bool blendingEnabled = false;
@@ -237,6 +250,31 @@ private:
 	friend class ScopedTranslate;
 
 	std::unique_ptr<GraphicsAPI> api;
+};
+
+// RAII once-per-frame callback. Hold one of these (e.g. as a member) and
+// fn gets called every frame until it goes out of scope. This is how
+// layers animate themselves - instead of a virtual update on Layer that
+// requires traversing the whole tree, anything that can see a Graphics
+// can have one of these.
+class ScopedUpdater {
+public:
+	ScopedUpdater(Graphics &g, std::function<void()> fn)
+		: g(g)
+		, fn(std::move(fn)) {
+		g.registerUpdater(this);
+	}
+	~ScopedUpdater() { g.unregisterUpdater(this); }
+
+	ScopedUpdater(const ScopedUpdater &)			= delete;
+	ScopedUpdater &operator=(const ScopedUpdater &) = delete;
+	ScopedUpdater(ScopedUpdater &&)					= delete;
+	ScopedUpdater &operator=(ScopedUpdater &&)		= delete;
+
+private:
+	friend class Graphics;
+	Graphics &g;
+	std::function<void()> fn;
 };
 
 template <Graphics::BlendMode newBlendMode>

--- a/lib/mzgl/ui/HierarchicalScrollingList.h
+++ b/lib/mzgl/ui/HierarchicalScrollingList.h
@@ -104,8 +104,8 @@ public:
 		if (!isPopping) ScrollingList::drawSelfAndChildren();
 	}
 
-	void updateDeprecated() override {
-		ScrollingList::updateDeprecated();
+	void onUpdate() override {
+		ScrollingList::onUpdate();
 		if (isPushing || isPopping) {
 			animationAmt += 0.05;
 

--- a/lib/mzgl/ui/Layer.cpp
+++ b/lib/mzgl/ui/Layer.cpp
@@ -357,18 +357,6 @@ bool Layer::_touchDown(float x, float y, int id) {
 	return false;
 }
 
-void Layer::_updateDeprecated() {
-	{
-#ifdef DEBUG
-		ScopedIterationGuard guard(*this);
-#endif
-		for (auto *c: children) {
-			c->_updateDeprecated();
-		}
-	}
-	updateDeprecated();
-}
-
 void Layer::sendToBack(Layer *child) {
 #ifdef DEBUG
 	if (child != nullptr) assertNotIterating("sendToBack");

--- a/lib/mzgl/ui/Layer.h
+++ b/lib/mzgl/ui/Layer.h
@@ -72,9 +72,6 @@ public:
 	virtual bool keyDown(int key) { return false; }
 	virtual void keyUp(int key) {}
 
-	// override to have something to do before the draw
-	virtual void updateDeprecated() {}
-
 	[[nodiscard]] int getNumChildren() const;
 	Layer *getChild(int index);
 	Layer *getFirstChild();
@@ -97,7 +94,6 @@ public:
 	bool _mouseZoomed(float x, float y, float zoom);
 	bool _keyDown(int key);
 	bool _keyUp(int key);
-	void _updateDeprecated();
 
 	Layer *getParent() const;
 	Layer *getRoot();

--- a/lib/mzgl/ui/Scroller.cpp
+++ b/lib/mzgl/ui/Scroller.cpp
@@ -60,7 +60,7 @@ void Scroller::clear() {
 	content->height = 0;
 }
 
-void Scroller::updateDeprecated() {
+void Scroller::onUpdate() {
 	double dt = std::clamp(static_cast<double>(g.frameDelta), 0.0, kMaxDt);
 
 	if (scrolling) {

--- a/lib/mzgl/ui/Scroller.h
+++ b/lib/mzgl/ui/Scroller.h
@@ -14,7 +14,6 @@ public:
 
 	void addContent(Layer *layer);
 	void clear() override;
-	void updateDeprecated() override;
 
 	void draw() override;
 
@@ -41,8 +40,12 @@ public:
 	vec4 color {1.f, 1.f, 1.f, 1.f};
 
 protected:
+	// once-per-frame scroll physics, driven by the ScopedUpdater below
+	virtual void onUpdate();
+
 	void drawScrollbar();
 	Layer *content;
+	ScopedUpdater updater {g, [this] { onUpdate(); }};
 	bool scrolling = false;
 	glm::vec2 lastTouch {0, 0};
 	// px / sec

--- a/lib/mzgl/ui/ScrollingList.cpp
+++ b/lib/mzgl/ui/ScrollingList.cpp
@@ -61,8 +61,8 @@ void ScrollingList::touchHeld() {
 	}
 }
 
-void ScrollingList::updateDeprecated() {
-	Scroller::updateDeprecated();
+void ScrollingList::onUpdate() {
+	Scroller::onUpdate();
 	if (emptyMessageLayer != nullptr) {
 		emptyMessageLayer->visible = empty();
 	}

--- a/lib/mzgl/ui/ScrollingList.h
+++ b/lib/mzgl/ui/ScrollingList.h
@@ -53,7 +53,6 @@ public:
 	float getContentHeight() { return content->height; }
 	//	void draw() override;
 	virtual void drawSelfAndChildren() override;
-	void updateDeprecated() override;
 	bool empty() const { return items.empty(); }
 
 	virtual bool keyDown(int key) override;
@@ -62,6 +61,7 @@ public:
 	auto end() { return items.end(); }
 
 protected:
+	void onUpdate() override;
 	int selectedIndex = -1;
 	void focus(int index);
 	void touchHeld();

--- a/lib/mzgl/ui/widgets/ReorderableItem.h
+++ b/lib/mzgl/ui/widgets/ReorderableItem.h
@@ -38,7 +38,8 @@ public:
 		}
 		return -1;
 	}
-	void updateDeprecated() override {
+	// once-per-frame snap-back animation, driven by the ScopedUpdater below
+	virtual void onUpdate() {
 		if (!dragging && !atOriginalPosition()) {
 			x = x * 0.8 + targetRect.x * 0.2;
 			y = y * 0.8 + targetRect.y * 0.2;
@@ -67,4 +68,7 @@ public:
 	bool dragging = false;
 	int touchId	  = -1;
 	vec2 touchStart;
+
+private:
+	ScopedUpdater updater {g, [this] { onUpdate(); }};
 };

--- a/lib/mzgl/util/EventDispatcher.h
+++ b/lib/mzgl/util/EventDispatcher.h
@@ -116,7 +116,7 @@ public:
 
 	void updateDeprecated() {
 		app->updateDeprecated();
-		app->root->_updateDeprecated();
+		app->g.runRegisteredUpdaters();
 	}
 
 	void draw() {


### PR DESCRIPTION
## What

`Layer::_updateDeprecated()` recursed through the entire layer tree every frame to find the few layers that actually override `updateDeprecated()`. Profiling Koala (816 layers) showed this traversal alone costing ~12% of draw-thread CPU — almost all of it self-time in the recursion/virtual dispatch, not in the update bodies.

This removes `Layer::updateDeprecated()` entirely and replaces it with **`ScopedUpdater`** — an RAII handle (defined in `Graphics.h` next to the other `Scoped*` types) that takes a `Graphics &` and a lambda, registers in its constructor and unregisters in its destructor:

```cpp
ScopedUpdater updater {g, [this] { onUpdate(); }};
```

- Anything that can see a `Graphics` can have one — not just layers.
- Update code cannot exist unregistered: the registration *is* the member. No forget-to-register failure mode.
- The list lives in `Graphics` (per-instance, no statics, plugin-safe); `EventDispatcher` calls `g.runRegisteredUpdaters()` once per frame.
- Safe against mutation during iteration: a `ScopedUpdater` destroyed mid-run nulls its slot (swept after the loop); one created mid-run executes the same frame.

Where an inheritance chain used to override `updateDeprecated()` (`Scroller` → `ScrollingList` → `HierarchicalScrollingList`, `ReorderableItem` → subclasses), the base class owns the single `ScopedUpdater` and exposes a `virtual void onUpdate()` hook — override-replaces-base semantics preserved exactly.

## Measured

Same scripted UI workload in Koala, 30s `sample` capture of the draw thread:

| | inclusive samples | self samples |
|---|---|---|
| `Layer::_updateDeprecated` traversal (before) | 236 | ~187 |
| registered-updater run (after) | 35 | ~0 |

The remaining 35 samples are the actual update bodies doing real work.

## Why RAII beats explicit registration

An earlier revision of this PR kept `virtual updateDeprecated()` + a `registerForUpdate()` call in each overriding constructor. Converting Koala exposed why that's fragile: two of its 23 registration calls landed in the wrong class (the overrides in `Keyboard.h` and `SongArranger.h` actually belong to `KeyboardArea` and `SequenceBlock` declared in the same headers) — both compiled fine and both updates silently never ran. With the `ScopedUpdater` member sitting next to the method it drives, that mistake isn't expressible.

## Breaking change for downstream apps

Any `Layer` subclass overriding `updateDeprecated()` no longer compiles (the virtual is gone) — loud, not silent. Mechanical fix per class: rename the method to `onUpdate()` and add the one-line `ScopedUpdater` member (see companion Koala PR elf-audio/koala#1631 for 23 worked examples). `App::updateDeprecated()` (the app-level hook) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)