### PR TITLE
Fix grid-keyboard note labels & AUv3 icons rendering as black rects (Metal)

### DIFF
--- a/lib/mzgl/app/mac/MacAppDelegate.mm
+++ b/lib/mzgl/app/mac/MacAppDelegate.mm
@@ -7,6 +7,7 @@
 //
 
 #import "MacAppDelegate.h"
+#import <MetalKit/MetalKit.h>
 #import "EventsView.h"
 #include "mainThread.h"
 #include "MacMenuBar.h"
@@ -38,6 +39,7 @@ void handleTerminateSignal(int signal) {
 	std::shared_ptr<App> app;
 	std::shared_ptr<EventDispatcher> eventDispatcher;
 	NSWindow *window;
+	id backgroundActivity;
 }
 @end
 
@@ -163,6 +165,40 @@ bool hasTransparentTitleBar = true;
 											 selector:@selector(screenDidChange:)
 												 name:NSWindowDidChangeScreenNotification
 											   object:window];
+
+	// When driving the app over the test server, force a draw every frame even
+	// when the window is occluded/backgrounded. MTKView normally pauses drawing
+	// in that state, which stalls the main-thread queue (runOnMainThreadAndWait
+	// is drained inside the frame loop) and hangs every test-server request.
+	if (hasCommandLineFlag("--start-test-server") || hasCommandLineFlag("--server")) {
+		// Stop App Nap from throttling our run loop / draw timer while the app
+		// is backgrounded - otherwise test-server requests stall for seconds.
+		backgroundActivity =
+			[[[NSProcessInfo processInfo] beginActivityWithOptions:NSActivityUserInitiated
+															reason:@"koala test server"] retain];
+
+		// Keep the window on top and on every Space so it is never occluded.
+		// MTKView pauses drawing when its window is hidden/occluded, which stalls
+		// the main-thread queue (drained inside the frame loop) and means there
+		// is no valid drawable to screenshot. This lets the harness drive and
+		// capture the UI without having to bring the app to the foreground.
+		window.level			 = NSFloatingWindowLevel;
+		window.collectionBehavior = NSWindowCollectionBehaviorCanJoinAllSpaces
+									| NSWindowCollectionBehaviorStationary;
+		[window orderFrontRegardless];
+
+		// Capture the view (lives for the app lifetime) rather than self, to
+		// avoid a retain cycle. This file is compiled without ARC, so no __weak.
+		id drawView		   = view;
+		NSTimer *drawTimer = [NSTimer timerWithTimeInterval:1.0 / 60.0
+													repeats:YES
+													  block:^(NSTimer *_Nonnull timer) {
+														if ([drawView isKindOfClass:[MTKView class]]) {
+															[(MTKView *) drawView draw];
+														}
+													  }];
+		[[NSRunLoop mainRunLoop] addTimer:drawTimer forMode:NSRunLoopCommonModes];
+	}
 }
 
 - (void)about:(id)event {

--- a/lib/mzgl/app/mac/Metal/MZMetalView.mm
+++ b/lib/mzgl/app/mac/Metal/MZMetalView.mm
@@ -2,9 +2,16 @@
 #include "sokol_gfx.h"
 #include "EventDispatcher.h"
 #include "SokolSetup.h"
+#include "Image.h"
+#include <mutex>
+#include <string>
 
 @implementation MZMetalView {
 	sg_pass_action pass_action;
+	id<MTLCommandQueue> captureQueue;
+	std::mutex screenshotMutex;
+	std::string screenshotPath;
+	bool screenshotPending;
 }
 
 static sg_pixel_format depth_format = SG_PIXELFORMAT_NONE;
@@ -29,13 +36,84 @@ static sg_pixel_format depth_format = SG_PIXELFORMAT_NONE;
 		self.clearColor = MTLClearColorMake(0.0, 0.0, 0.0, 1.0);
 		[self setDrawableSize:[self convertSizeToBacking:frame.size]];
 
+		// Allow the drawable texture to be used as a blit source so we can read
+		// it back for screenshots (saveScreen). Without this the drawable is
+		// framebuffer-only and the blit below is invalid.
+		self.framebufferOnly = NO;
+		captureQueue		 = [self.device newCommandQueue];
+		screenshotPending	 = false;
+
 		// TODO: this might be why it looks a bit crispy, try linear?
 		//		[self.layer setMagnificationFilter:kCAFilterNearest];
 
 		// setup sokol
 		mzglSokolSetup(osx_environment(self));
+
+		// Install the deferred screenshot hook. Graphics::saveScreen() (and the
+		// WS test server's save-screen action) just flag a request here; the
+		// actual readback happens at the end of the next frame in drawInMTKView,
+		// where a fully-rendered drawable exists - reading it synchronously from
+		// the render thread would otherwise deadlock or capture an empty frame.
+		// Plain pointer capture: this is a C++ lambda (not an ObjC block) in an
+		// MRC file, so it does not retain self - no retain cycle. The view lives
+		// for the app's lifetime, alongside the Graphics that owns this lambda.
+		MZMetalView *rawSelf = self;
+		eventDispatcher->app->g.deferredSaveScreen = [rawSelf](const std::string &path) -> bool {
+			if (rawSelf == nil) return false;
+			std::lock_guard<std::mutex> lock(rawSelf->screenshotMutex);
+			rawSelf->screenshotPath	   = path;
+			rawSelf->screenshotPending = true;
+			return true;
+		};
 	}
 	return self;
+}
+
+- (void)captureScreenshotIfRequested {
+	std::string path;
+	{
+		std::lock_guard<std::mutex> lock(screenshotMutex);
+		if (!screenshotPending) return;
+		screenshotPending = false;
+		path			  = screenshotPath;
+	}
+
+	id<CAMetalDrawable> drawable = self.currentDrawable;
+	if (drawable == nil) return;
+	id<MTLTexture> tex = drawable.texture;
+
+	NSUInteger w		   = tex.width;
+	NSUInteger h		   = tex.height;
+	NSUInteger bytesPerRow = w * 4;
+	id<MTLBuffer> buffer   = [self.device newBufferWithLength:bytesPerRow * h
+													 options:MTLResourceStorageModeShared];
+
+	id<MTLCommandBuffer> cmd	  = [captureQueue commandBuffer];
+	id<MTLBlitCommandEncoder> blit = [cmd blitCommandEncoder];
+	[blit copyFromTexture:tex
+				 sourceSlice:0
+				 sourceLevel:0
+				sourceOrigin:MTLOriginMake(0, 0, 0)
+				  sourceSize:MTLSizeMake(w, h, 1)
+					toBuffer:buffer
+		   destinationOffset:0
+	  destinationBytesPerRow:bytesPerRow
+	destinationBytesPerImage:bytesPerRow * h];
+	[blit endEncoding];
+	[cmd commit];
+	[cmd waitUntilCompleted];
+
+	// Drawable is BGRA8; convert to RGBA and force opaque. Metal's drawable
+	// origin is top-left so no vertical flip is needed (unlike the GL path).
+	const uint8_t *src = (const uint8_t *) buffer.contents;
+	std::vector<uint8_t> rgba(w * h * 4);
+	for (NSUInteger i = 0; i < w * h; i++) {
+		rgba[i * 4 + 0] = src[i * 4 + 2];
+		rgba[i * 4 + 1] = src[i * 4 + 1];
+		rgba[i * 4 + 2] = src[i * 4 + 0];
+		rgba[i * 4 + 3] = 255;
+	}
+	Image::save(path, rgba.data(), (int) w, (int) h, 4, 1, false);
 }
 
 - (void)disableDrawing {
@@ -91,6 +169,8 @@ sg_swapchain osx_swapchain(MTKView *mtkView) {
 		eventDispatcher->runFrame();
 		sg_end_pass();
 		sg_commit();
+
+		[self captureScreenshotIfRequested];
 	}
 }
 - (void)mtkView:(nonnull MTKView *)view drawableSizeWillChange:(CGSize)size {

--- a/lib/mzgl/gl/Graphics.cpp
+++ b/lib/mzgl/gl/Graphics.cpp
@@ -532,6 +532,12 @@ void Graphics::drawTextHorizontallyCentred(const std::string &text, glm::vec2 c)
 }
 
 void Graphics::saveScreen(std::string pngPath) {
+	// On Metal/sokol the synchronous readScreenPixels path is a no-op (the
+	// drawable is read back asynchronously by the render view instead).
+	if (deferredSaveScreen && deferredSaveScreen(pngPath)) {
+		return;
+	}
+
 	ImageRef img = Image::create(width, height, 4);
 
 	api->readScreenPixels(img->data, Rectf(0, 0, width, height));

--- a/lib/mzgl/gl/Graphics.h
+++ b/lib/mzgl/gl/Graphics.h
@@ -81,6 +81,12 @@ public:
 	void setHexColor(int hex, float a = 1.f);
 	void saveScreen(std::string pngPath);
 
+	// On Metal the default framebuffer can't be read back synchronously the way
+	// glReadPixels allows, so the platform render view installs this hook to grab
+	// the next fully-rendered frame and write it to a PNG. Returns true if it
+	// handled the request, in which case saveScreen() skips the GL readback path.
+	std::function<bool(const std::string &)> deferredSaveScreen;
+
 	std::function<void(bool)> setAntialiasing = [](bool) {};
 
 	enum class BlendMode {

--- a/lib/mzgl/gl/api/sokol/SokolSetup.h
+++ b/lib/mzgl/gl/api/sokol/SokolSetup.h
@@ -19,5 +19,8 @@ inline void mzglSokolSetup(const sg_environment &environment) {
 	desc.buffer_pool_size	= 4096; // sokol default is 128
 	desc.shader_pool_size	= 128; // sokol default is 32
 	desc.pipeline_pool_size = 512; // sokol default of 64 is too small (one pipeline per shader/blend/primitive combo)
+	desc.image_pool_size	= 1024; // sokol default of 128 is too small - font atlases, AUv3 plugin icons,
+									// waveform/sample textures all consume image slots at runtime. Exhausting the
+									// pool makes sg_make_image return SG_INVALID_ID and textures render as black rects.
 	sg_setup(desc);
 }

--- a/lib/mzgl/gl/api/sokol/SokolVbo.cpp
+++ b/lib/mzgl/gl/api/sokol/SokolVbo.cpp
@@ -73,15 +73,22 @@ void SokolVbo::draw_(Graphics &g, Vbo::PrimitiveType mode, size_t numInstances) 
 	bindings.vertex_buffers[0]	= positionBuffer.buffer;
 	int nextPos					= 1;
 
-	if (colorBuffer.valid()) {
-		bindings.vertex_buffers[nextPos] = colorBuffer.buffer;
-		attrs.push_back(colorBuffer.getFormat());
-		nextPos++;
-	}
-
+	// Order matters: each buffer at slot i feeds the shader attribute at location
+	// i (SokolPipeline sets buffer_index = i). Every shader declares its vertex
+	// attributes as Position, then TexCoord, then Color, so texcoords must be
+	// bound before colors. Binding color first swaps the two for the color+
+	// texcoord shaders (colorFont/colorTexture): TexCoord then reads colour data
+	// and samples a constant atlas texel - e.g. grid keyboard note names render
+	// as solid black rects.
 	if (texCoordBuffer.valid()) {
 		bindings.vertex_buffers[nextPos] = texCoordBuffer.buffer;
 		attrs.push_back(texCoordBuffer.getFormat());
+		nextPos++;
+	}
+
+	if (colorBuffer.valid()) {
+		bindings.vertex_buffers[nextPos] = colorBuffer.buffer;
+		attrs.push_back(colorBuffer.getFormat());
 		nextPos++;
 	}
 

--- a/lib/mzgl/gl/api/sokol/SokolVbo.cpp
+++ b/lib/mzgl/gl/api/sokol/SokolVbo.cpp
@@ -31,6 +31,14 @@ SokolShader *SokolVbo::getShader(Graphics &g) const {
 	}
 	if (colorBuffer.valid()) {
 		if (texCoordBuffer.valid()) {
+			// colorFontShader and colorTextureShader share the same vertex layout
+			// (pos+texcoord+color) so the auto-pick can't tell them apart. They
+			// differ in the fragment stage: colorFont treats the texture as an R8
+			// alpha mask (a *= tex.r), colorTexture multiplies rgba. Honour an
+			// explicitly-bound colorFontShader, else assume a real texture.
+			if (g.currShader == g.colorFontShader.get()) {
+				return dynamic_cast<SokolShader *>(g.colorFontShader.get());
+			}
 			return dynamic_cast<SokolShader *>(g.colorTextureShader.get());
 		}
 		return dynamic_cast<SokolShader *>(g.colorShader.get());

--- a/lib/mzgl/gl/api/sokol/sokolFontstash.h
+++ b/lib/mzgl/gl/api/sokol/sokolFontstash.h
@@ -45,6 +45,18 @@ static int sokolFons__renderCreate(void *userPtr, int width, int height) {
 }
 
 static int sokolFons__renderResize(void *userPtr, int width, int height) {
+	sokolFONScontext *gl = (sokolFONScontext *) userPtr;
+	// Atlas grew: fontstash asks us to make a bigger texture. The old image is
+	// still live here - destroy it first, otherwise we leak one sokol image slot
+	// per atlas growth (512->1024->2048...). The wrapper TextureRef we made for it
+	// has owns=false so it won't free it either. Leaked slots eventually exhaust
+	// the image pool -> sg_make_image returns SG_INVALID_ID -> glyphs/icons bind a
+	// dead texture and render as solid (black) rects. renderCreate asserts the
+	// handle is invalid, so we must clear it before delegating.
+	if (gl->tex.id != SG_INVALID_ID && sg_isvalid()) {
+		sg_destroy_image(gl->tex);
+	}
+	gl->tex = (sg_image) {SG_INVALID_ID};
 	return sokolFons__renderCreate(userPtr, width, height);
 }
 


### PR DESCRIPTION
## Problem

On the new sokol/Metal backend, the **GridKeyboard note-name labels render as solid black rects** (and AUv3 plugin icons sometimes don't display). Reproduced and fixed; see before/after below.

## Root cause (the real one) — `baf5120`

`SokolVbo::draw_` bound vertex buffers in the order **position, color, texcoord**, but `SokolPipeline` maps buffer slot *i* to shader attribute **location *i***, and every shader declares its attributes as **Position, TexCoord, Color**. So for the two shaders that use *both* colour and texcoords — `colorFont` and `colorTexture` — the buffers were swapped: the `TexCoord` attribute read the colour data and vice-versa.

- Coloured text (`ColorTextDrawer` → `colorFont`, e.g. the grid note labels): each glyph's texcoord became the colour value `(0,0,…)`, so it sampled a constant atlas texel (fontstash's solid white corner) → **solid black rectangle** instead of the note name.
- `colorTexture` (tinted textures, e.g. **AUv3 plugin icons**) hits the same swap.

Fix: bind texcoords before colours so the buffer order matches every shader's attribute declaration order.

**Before:** note labels = black rects · **After:** `C3 D#3 F3 G3 …` render correctly.

## Also included

- `ec00bda` — `sokolFons__renderResize` leaked one sokol image per font-atlas growth (the guarding `mzAssert` is compiled out in release); plus the image pool was left at sokol's default of 128 while the other pools were raised. A genuine, separate resource leak — kept as hardening, though it is **not** the cause of the black rects above.
- `b089173` — headless screenshot support for the WebSocket test server (Metal framebuffer readback via a deferred drawable blit, plus keeping the window drawable/queue alive when backgrounded). This is what let me reproduce, capture and verify the fix on a headless Mac.

## Verification

Captured live from the running Metal app via the test server (grid keyboard + show note names): black rects before, correct note names after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)