### PR TITLE
Fix grid-keyboard note labels & AUv3 icons rendering as black/red rects (Metal)

### DIFF
--- a/lib/mzgl/gl/api/sokol/SokolSetup.h
+++ b/lib/mzgl/gl/api/sokol/SokolSetup.h
@@ -19,5 +19,10 @@ inline void mzglSokolSetup(const sg_environment &environment) {
 	desc.buffer_pool_size	= 4096; // sokol default is 128
 	desc.shader_pool_size	= 128; // sokol default is 32
 	desc.pipeline_pool_size = 512; // sokol default of 64 is too small (one pipeline per shader/blend/primitive combo)
+	desc.image_pool_size	= 256; // sokol default of 128 is too small - font atlases, AUv3 plugin icons,
+									// waveform/sample textures all consume image slots at runtime. Exhausting the
+									// pool makes sg_make_image return SG_INVALID_ID and textures render as black rects.
+									// 256 is comfortably above peak concurrent images; the pool is just CPU-side
+									// handle bookkeeping (~100 bytes/slot), no GPU/texture memory.
 	sg_setup(desc);
 }

--- a/lib/mzgl/gl/api/sokol/SokolVbo.cpp
+++ b/lib/mzgl/gl/api/sokol/SokolVbo.cpp
@@ -73,15 +73,22 @@ void SokolVbo::draw_(Graphics &g, Vbo::PrimitiveType mode, size_t numInstances) 
 	bindings.vertex_buffers[0]	= positionBuffer.buffer;
 	int nextPos					= 1;
 
-	if (colorBuffer.valid()) {
-		bindings.vertex_buffers[nextPos] = colorBuffer.buffer;
-		attrs.push_back(colorBuffer.getFormat());
-		nextPos++;
-	}
-
+	// Order matters: each buffer at slot i feeds the shader attribute at location
+	// i (SokolPipeline sets buffer_index = i). Every shader declares its vertex
+	// attributes as Position, then TexCoord, then Color, so texcoords must be
+	// bound before colors. Binding color first swaps the two for the color+
+	// texcoord shaders (colorFont/colorTexture): TexCoord then reads colour data
+	// and samples a constant atlas texel - e.g. grid keyboard note names render
+	// as solid black rects.
 	if (texCoordBuffer.valid()) {
 		bindings.vertex_buffers[nextPos] = texCoordBuffer.buffer;
 		attrs.push_back(texCoordBuffer.getFormat());
+		nextPos++;
+	}
+
+	if (colorBuffer.valid()) {
+		bindings.vertex_buffers[nextPos] = colorBuffer.buffer;
+		attrs.push_back(colorBuffer.getFormat());
 		nextPos++;
 	}
 

--- a/lib/mzgl/gl/api/sokol/SokolVbo.cpp
+++ b/lib/mzgl/gl/api/sokol/SokolVbo.cpp
@@ -31,6 +31,14 @@ SokolShader *SokolVbo::getShader(Graphics &g) const {
 	}
 	if (colorBuffer.valid()) {
 		if (texCoordBuffer.valid()) {
+			// colorFontShader and colorTextureShader share the same vertex layout
+			// (pos+texcoord+color) so the auto-pick can't tell them apart. They
+			// differ in the fragment stage: colorFont treats the texture as an R8
+			// alpha mask (a *= tex.r), colorTexture multiplies rgba. Honour an
+			// explicitly-bound colorFontShader, else assume a real texture.
+			if (g.currShader == g.colorFontShader.get()) {
+				return dynamic_cast<SokolShader *>(g.colorFontShader.get());
+			}
 			return dynamic_cast<SokolShader *>(g.colorTextureShader.get());
 		}
 		return dynamic_cast<SokolShader *>(g.colorShader.get());

--- a/lib/mzgl/gl/api/sokol/sokolFontstash.h
+++ b/lib/mzgl/gl/api/sokol/sokolFontstash.h
@@ -45,6 +45,18 @@ static int sokolFons__renderCreate(void *userPtr, int width, int height) {
 }
 
 static int sokolFons__renderResize(void *userPtr, int width, int height) {
+	sokolFONScontext *gl = (sokolFONScontext *) userPtr;
+	// Atlas grew: fontstash asks us to make a bigger texture. The old image is
+	// still live here - destroy it first, otherwise we leak one sokol image slot
+	// per atlas growth (512->1024->2048...). The wrapper TextureRef we made for it
+	// has owns=false so it won't free it either. Leaked slots eventually exhaust
+	// the image pool -> sg_make_image returns SG_INVALID_ID -> glyphs/icons bind a
+	// dead texture and render as solid (black) rects. renderCreate asserts the
+	// handle is invalid, so we must clear it before delegating.
+	if (gl->tex.id != SG_INVALID_ID && sg_isvalid()) {
+		sg_destroy_image(gl->tex);
+	}
+	gl->tex = (sg_image) {SG_INVALID_ID};
 	return sokolFons__renderCreate(userPtr, width, height);
 }
 


### PR DESCRIPTION
Pure graphics fix for the sokol/Metal backend. No test-harness changes (those are split into the headless-screenshots PR).

## Symptoms
GridKeyboard "show note names" labels rendered as solid black rects; after a partial fix, as red text on a faint dark box. AUv3 plugin icons sometimes didn't display. All regressions from the OpenGL → sokol/Metal move. Other text was fine because it uses the uniform-colour `font` shader; only the per-vertex coloured path (`ColorTextDrawer` → `colorFont`) was affected.

## Fixes
1. **`df0b439` Swapped color/texcoord vertex attributes.** `SokolVbo::draw_` bound buffers `position, color, texcoord`, but `SokolPipeline` maps buffer slot *i* to shader attribute location *i*, and every shader declares `Position, TexCoord, Color`. So for the colour+texcoord shaders (`colorFont`, `colorTexture`) TexCoord read the colour data → each glyph sampled a constant atlas texel → solid black rects. Bind texcoords before colours. (Also fixes `colorTexture`, i.e. tinted textures / AUv3 icons.)

2. **`65ae74e` Wrong shader for coloured text.** `getShader` picked `colorTextureShader` (`fragColor = texture * colorV`) for any colour+texcoord VBO, ignoring an explicitly-bound `colorFontShader` (`fragColor = colorV; a *= tex.r`). On the R8 font atlas `(r,0,0,1) * colorV` killed G/B and left a faint box → red text. Honour a bound `colorFontShader`, mirroring the existing `fontShader` special-case.

3. **`d26e1cc` Atlas-grow image leak + pool size.** `sokolFons__renderResize` leaked one sokol image per font-atlas growth (guarding `mzAssert` compiled out in release); image pool left at sokol's default 128 while other pools were raised. Separate resource leak — hardening, not the cause of the rects above.

## Verification
Captured live from the running Metal app: black rects → red+box → correct faint-white note names (C3, D#3, F3 …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)