### PR TITLE
Headless UI screenshots over the test server (macOS/Metal)

### DIFF
--- a/lib/mzgl/app/mac/MacAppDelegate.mm
+++ b/lib/mzgl/app/mac/MacAppDelegate.mm
@@ -7,6 +7,7 @@
 //
 
 #import "MacAppDelegate.h"
+#import <MetalKit/MetalKit.h>
 #import "EventsView.h"
 #include "mainThread.h"
 #include "MacMenuBar.h"
@@ -38,6 +39,7 @@ void handleTerminateSignal(int signal) {
 	std::shared_ptr<App> app;
 	std::shared_ptr<EventDispatcher> eventDispatcher;
 	NSWindow *window;
+	id backgroundActivity;
 }
 @end
 
@@ -163,6 +165,40 @@ bool hasTransparentTitleBar = true;
 											 selector:@selector(screenDidChange:)
 												 name:NSWindowDidChangeScreenNotification
 											   object:window];
+
+	// When driving the app over the test server, force a draw every frame even
+	// when the window is occluded/backgrounded. MTKView normally pauses drawing
+	// in that state, which stalls the main-thread queue (runOnMainThreadAndWait
+	// is drained inside the frame loop) and hangs every test-server request.
+	if (hasCommandLineFlag("--start-test-server") || hasCommandLineFlag("--server")) {
+		// Stop App Nap from throttling our run loop / draw timer while the app
+		// is backgrounded - otherwise test-server requests stall for seconds.
+		backgroundActivity =
+			[[[NSProcessInfo processInfo] beginActivityWithOptions:NSActivityUserInitiated
+															reason:@"koala test server"] retain];
+
+		// Keep the window on top and on every Space so it is never occluded.
+		// MTKView pauses drawing when its window is hidden/occluded, which stalls
+		// the main-thread queue (drained inside the frame loop) and means there
+		// is no valid drawable to screenshot. This lets the harness drive and
+		// capture the UI without having to bring the app to the foreground.
+		window.level			 = NSFloatingWindowLevel;
+		window.collectionBehavior = NSWindowCollectionBehaviorCanJoinAllSpaces
+									| NSWindowCollectionBehaviorStationary;
+		[window orderFrontRegardless];
+
+		// Capture the view (lives for the app lifetime) rather than self, to
+		// avoid a retain cycle. This file is compiled without ARC, so no __weak.
+		id drawView		   = view;
+		NSTimer *drawTimer = [NSTimer timerWithTimeInterval:1.0 / 60.0
+													repeats:YES
+													  block:^(NSTimer *_Nonnull timer) {
+														if ([drawView isKindOfClass:[MTKView class]]) {
+															[(MTKView *) drawView draw];
+														}
+													  }];
+		[[NSRunLoop mainRunLoop] addTimer:drawTimer forMode:NSRunLoopCommonModes];
+	}
 }
 
 - (void)about:(id)event {

--- a/lib/mzgl/app/mac/Metal/MZMetalView.mm
+++ b/lib/mzgl/app/mac/Metal/MZMetalView.mm
@@ -2,9 +2,16 @@
 #include "sokol_gfx.h"
 #include "EventDispatcher.h"
 #include "SokolSetup.h"
+#include "Image.h"
+#include <mutex>
+#include <string>
 
 @implementation MZMetalView {
 	sg_pass_action pass_action;
+	id<MTLCommandQueue> captureQueue;
+	std::mutex screenshotMutex;
+	std::string screenshotPath;
+	bool screenshotPending;
 }
 
 static sg_pixel_format depth_format = SG_PIXELFORMAT_NONE;
@@ -29,13 +36,84 @@ static sg_pixel_format depth_format = SG_PIXELFORMAT_NONE;
 		self.clearColor = MTLClearColorMake(0.0, 0.0, 0.0, 1.0);
 		[self setDrawableSize:[self convertSizeToBacking:frame.size]];
 
+		// Allow the drawable texture to be used as a blit source so we can read
+		// it back for screenshots (saveScreen). Without this the drawable is
+		// framebuffer-only and the blit below is invalid.
+		self.framebufferOnly = NO;
+		captureQueue		 = [self.device newCommandQueue];
+		screenshotPending	 = false;
+
 		// TODO: this might be why it looks a bit crispy, try linear?
 		//		[self.layer setMagnificationFilter:kCAFilterNearest];
 
 		// setup sokol
 		mzglSokolSetup(osx_environment(self));
+
+		// Install the deferred screenshot hook. Graphics::saveScreen() (and the
+		// WS test server's save-screen action) just flag a request here; the
+		// actual readback happens at the end of the next frame in drawInMTKView,
+		// where a fully-rendered drawable exists - reading it synchronously from
+		// the render thread would otherwise deadlock or capture an empty frame.
+		// Plain pointer capture: this is a C++ lambda (not an ObjC block) in an
+		// MRC file, so it does not retain self - no retain cycle. The view lives
+		// for the app's lifetime, alongside the Graphics that owns this lambda.
+		MZMetalView *rawSelf = self;
+		eventDispatcher->app->g.deferredSaveScreen = [rawSelf](const std::string &path) -> bool {
+			if (rawSelf == nil) return false;
+			std::lock_guard<std::mutex> lock(rawSelf->screenshotMutex);
+			rawSelf->screenshotPath	   = path;
+			rawSelf->screenshotPending = true;
+			return true;
+		};
 	}
 	return self;
+}
+
+- (void)captureScreenshotIfRequested {
+	std::string path;
+	{
+		std::lock_guard<std::mutex> lock(screenshotMutex);
+		if (!screenshotPending) return;
+		screenshotPending = false;
+		path			  = screenshotPath;
+	}
+
+	id<CAMetalDrawable> drawable = self.currentDrawable;
+	if (drawable == nil) return;
+	id<MTLTexture> tex = drawable.texture;
+
+	NSUInteger w		   = tex.width;
+	NSUInteger h		   = tex.height;
+	NSUInteger bytesPerRow = w * 4;
+	id<MTLBuffer> buffer   = [self.device newBufferWithLength:bytesPerRow * h
+													 options:MTLResourceStorageModeShared];
+
+	id<MTLCommandBuffer> cmd	  = [captureQueue commandBuffer];
+	id<MTLBlitCommandEncoder> blit = [cmd blitCommandEncoder];
+	[blit copyFromTexture:tex
+				 sourceSlice:0
+				 sourceLevel:0
+				sourceOrigin:MTLOriginMake(0, 0, 0)
+				  sourceSize:MTLSizeMake(w, h, 1)
+					toBuffer:buffer
+		   destinationOffset:0
+	  destinationBytesPerRow:bytesPerRow
+	destinationBytesPerImage:bytesPerRow * h];
+	[blit endEncoding];
+	[cmd commit];
+	[cmd waitUntilCompleted];
+
+	// Drawable is BGRA8; convert to RGBA and force opaque. Metal's drawable
+	// origin is top-left so no vertical flip is needed (unlike the GL path).
+	const uint8_t *src = (const uint8_t *) buffer.contents;
+	std::vector<uint8_t> rgba(w * h * 4);
+	for (NSUInteger i = 0; i < w * h; i++) {
+		rgba[i * 4 + 0] = src[i * 4 + 2];
+		rgba[i * 4 + 1] = src[i * 4 + 1];
+		rgba[i * 4 + 2] = src[i * 4 + 0];
+		rgba[i * 4 + 3] = 255;
+	}
+	Image::save(path, rgba.data(), (int) w, (int) h, 4, 1, false);
 }
 
 - (void)disableDrawing {
@@ -91,6 +169,8 @@ sg_swapchain osx_swapchain(MTKView *mtkView) {
 		eventDispatcher->runFrame();
 		sg_end_pass();
 		sg_commit();
+
+		[self captureScreenshotIfRequested];
 	}
 }
 - (void)mtkView:(nonnull MTKView *)view drawableSizeWillChange:(CGSize)size {

--- a/lib/mzgl/gl/Graphics.cpp
+++ b/lib/mzgl/gl/Graphics.cpp
@@ -532,6 +532,12 @@ void Graphics::drawTextHorizontallyCentred(const std::string &text, glm::vec2 c)
 }
 
 void Graphics::saveScreen(std::string pngPath) {
+	// On Metal/sokol the synchronous readScreenPixels path is a no-op (the
+	// drawable is read back asynchronously by the render view instead).
+	if (deferredSaveScreen && deferredSaveScreen(pngPath)) {
+		return;
+	}
+
 	ImageRef img = Image::create(width, height, 4);
 
 	api->readScreenPixels(img->data, Rectf(0, 0, width, height));

--- a/lib/mzgl/gl/Graphics.h
+++ b/lib/mzgl/gl/Graphics.h
@@ -81,6 +81,12 @@ public:
 	void setHexColor(int hex, float a = 1.f);
 	void saveScreen(std::string pngPath);
 
+	// On Metal the default framebuffer can't be read back synchronously the way
+	// glReadPixels allows, so the platform render view installs this hook to grab
+	// the next fully-rendered frame and write it to a PNG. Returns true if it
+	// handled the request, in which case saveScreen() skips the GL readback path.
+	std::function<bool(const std::string &)> deferredSaveScreen;
+
 	std::function<void(bool)> setAntialiasing = [](bool) {};
 
 	enum class BlendMode {


### PR DESCRIPTION
Test/automation infrastructure to drive and screenshot the UI from the WebSocket test server on a headless / backgrounded Mac. No rendering-behaviour changes. Pairs with koala#1637 (the `save-screen` / `set-keyboard-mode` actions).

- `SokolAPI::readScreenPixels` is a no-op on Metal, so `Graphics::saveScreen` couldn't read back the framebuffer. Add a `deferredSaveScreen` hook that the Metal view fulfils by blitting the drawable to a shared buffer at the end of the next frame (`framebufferOnly` disabled to allow the blit).
- When the test server is enabled, `MacAppDelegate` keeps the window on top and on all Spaces, disables App Nap and force-draws via a timer, so the main-thread queue (drained inside the frame loop) keeps running and a valid drawable exists even when the app is occluded/backgrounded.

Used to reproduce and verify mzgl#104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)