### PR TITLE
Fix MSVC C4576 (C-style compound literal) in sokolFontstash

### DIFF
--- a/lib/mzgl/gl/api/sokol/sokolFontstash.h
+++ b/lib/mzgl/gl/api/sokol/sokolFontstash.h
@@ -56,7 +56,7 @@ static int sokolFons__renderResize(void *userPtr, int width, int height) {
 	if (gl->tex.id != SG_INVALID_ID && sg_isvalid()) {
 		sg_destroy_image(gl->tex);
 	}
-	gl->tex = (sg_image) {SG_INVALID_ID};
+	gl->tex = sg_image {SG_INVALID_ID};
 	return sokolFons__renderCreate(userPtr, width, height);
 }
 


### PR DESCRIPTION
The atlas-leak fix used a C-style compound literal `(sg_image){SG_INVALID_ID}` in `sokolFons__renderResize`. Clang accepts it; MSVC rejects it (C4576), breaking the Windows/D3D11 build. Use a C++ braced init instead.