### PR TITLE
Bind vertex attributes by name, not buffer order (sokol)

### DIFF
--- a/lib/mzgl/gl/api/sokol/SokolPipeline.h
+++ b/lib/mzgl/gl/api/sokol/SokolPipeline.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "Graphics.h"
 #include "sokol_gfx.h"
+#include "SokolVertexAttr.h"
 #include "log.h"
 #include <memory>
 #include <vector>
@@ -10,14 +11,12 @@ using PipelineRef = std::shared_ptr<Pipeline>;
 class Pipeline {
 public:
 	static PipelineRef create(sg_shader shd,
-							  const std::vector<sg_vertex_format> &attrs,
+							  const std::vector<SokolVertexAttr> &attrs,
 							  bool usingIndices,
 							  bool blending,
 							  Graphics::BlendMode blendMode,
-							  sg_primitive_type mode,
-							  bool isInstancing) {
-		return std::shared_ptr<Pipeline>(
-			new Pipeline(shd, attrs, usingIndices, blending, blendMode, mode, isInstancing));
+							  sg_primitive_type mode) {
+		return std::shared_ptr<Pipeline>(new Pipeline(shd, attrs, usingIndices, blending, blendMode, mode));
 	}
 
 	// sg_isvalid() guard: the layer tree can outlive sg_shutdown() on close,
@@ -45,26 +44,27 @@ public:
 
 private:
 	Pipeline(sg_shader shd,
-			 const std::vector<sg_vertex_format> &attrs,
+			 const std::vector<SokolVertexAttr> &attrs,
 			 bool usingIndices,
 			 bool blending,
 			 Graphics::BlendMode blendMode,
-			 sg_primitive_type mode,
-			 bool isInstancing) {
+			 sg_primitive_type mode) {
 		pipelineDesc				= {};
 		pipelineDesc.shader			= shd;
 		pipelineDesc.index_type		= usingIndices ? SG_INDEXTYPE_UINT32 : SG_INDEXTYPE_NONE;
 		pipelineDesc.primitive_type = mode;
 		pipelineDesc.sample_count	= sg_query_desc().environment.defaults.sample_count;
 
-		for (int i = 0; i < (int) attrs.size(); i++) {
-			pipelineDesc.layout.attrs[i].format		  = attrs[i];
-			pipelineDesc.layout.attrs[i].buffer_index = i;
-		}
-		if (isInstancing) {
-			int instanceIndexBuffer									   = static_cast<int>(attrs.size()) - 1;
-			pipelineDesc.layout.buffers[instanceIndexBuffer].step_func = SG_VERTEXSTEP_PER_INSTANCE;
-			pipelineDesc.layout.buffers[instanceIndexBuffer].step_rate = 1;
+		// Each attribute is placed at the shader location resolved by name (a.location)
+		// and reads from its own vertex-buffer slot (a.bufferSlot). This decouples the
+		// order buffers are bound from the order attributes are declared in the shader.
+		for (const auto &a: attrs) {
+			pipelineDesc.layout.attrs[a.location].format	   = a.format;
+			pipelineDesc.layout.attrs[a.location].buffer_index = a.bufferSlot;
+			if (a.perInstance) {
+				pipelineDesc.layout.buffers[a.bufferSlot].step_func = SG_VERTEXSTEP_PER_INSTANCE;
+				pipelineDesc.layout.buffers[a.bufferSlot].step_rate = 1;
+			}
 		}
 		if (blending) {
 			pipelineDesc.colors[0].blend.enabled = true;

--- a/lib/mzgl/gl/api/sokol/SokolShader.cpp
+++ b/lib/mzgl/gl/api/sokol/SokolShader.cpp
@@ -42,23 +42,35 @@ void SokolShader::end() {
 	g.currShader = nullptr;
 }
 
-PipelineRef SokolShader::getPipeline(const std::vector<sg_vertex_format> &attrs,
+int SokolShader::attrSlot(const std::string &attrName) const {
+	return def->attrSlotFunc(attrName.c_str());
+}
+
+PipelineRef SokolShader::getPipeline(const std::vector<SokolVertexAttr> &attrs,
 									 bool usingIndices,
-									 sg_primitive_type mode,
-									 bool isInstancing) {
-	// make a unique number to use as a key based on incoming parameters
-	// (there will be at most 5-6 attributes)
+									 sg_primitive_type mode) {
+	// Cache key hashes the full attribute layout (location/format/slot/step) plus
+	// the index/blend/primitive state, so different attribute sets for the same
+	// shader get distinct pipelines.
+	size_t key = 0;
+	auto mix   = [&key](size_t v) { key = key * 1000003u ^ v; };
+	for (const auto &a: attrs) {
+		mix(static_cast<size_t>(a.location));
+		mix(static_cast<size_t>(a.format));
+		mix(static_cast<size_t>(a.bufferSlot));
+		mix(a.perInstance ? 1u : 0u);
+	}
+	mix(usingIndices ? 1u : 0u);
+	mix(static_cast<size_t>(g.getBlendMode()));
+	mix(g.isBlending() ? 1u : 0u);
+	mix(static_cast<size_t>(mode));
 
-	int index = static_cast<int>(attrs.size()) + usingIndices * 16 + static_cast<int>(g.getBlendMode()) * 32 + g.isBlending() * 64
-				+ static_cast<int>(mode) * 128;
-
-	if (pipelines.find(index) == pipelines.end()) {
-		auto pipeline =
-			Pipeline::create(shd, attrs, usingIndices, g.isBlending(), g.getBlendMode(), mode, isInstancing);
-		pipelines[index] = pipeline;
+	if (pipelines.find(key) == pipelines.end()) {
+		auto pipeline = Pipeline::create(shd, attrs, usingIndices, g.isBlending(), g.getBlendMode(), mode);
+		pipelines[key] = pipeline;
 		return pipeline;
 	}
-	return pipelines[index];
+	return pipelines[key];
 }
 uint8_t *SokolShader::uniformLocation(const std::string &name) {
 	int offset = def->uniformOffsetFunc(SG_SHADERSTAGE_VS, "vertParams", name.c_str());

--- a/lib/mzgl/gl/api/sokol/SokolShader.h
+++ b/lib/mzgl/gl/api/sokol/SokolShader.h
@@ -3,10 +3,12 @@
 #include <glm/glm.hpp>
 using namespace glm;
 #include "sokol_gfx.h"
+#include "SokolVertexAttr.h"
 #include <map>
 #include <memory>
 #include <string>
 #include <cstring>
+#include <vector>
 #include "Shader.h"
 class Graphics;
 
@@ -100,12 +102,16 @@ public:
 		memcpy(ptr, data, sizeof(T) * count);
 	}
 
-	std::map<int, PipelineRef> pipelines;
+	std::map<size_t, PipelineRef> pipelines;
 
-	PipelineRef getPipeline(const std::vector<sg_vertex_format> &attrs,
+	// Shader attribute location for a vertex attribute by name (e.g. "Position",
+	// "Color", "TexCoord"), from the sokol-shdc reflection. Returns -1 if the
+	// shader doesn't use that attribute.
+	int attrSlot(const std::string &attrName) const;
+
+	PipelineRef getPipeline(const std::vector<SokolVertexAttr> &attrs,
 							bool usingIndices,
-							sg_primitive_type mode,
-							bool isInstancing);
+							sg_primitive_type mode);
 	std::vector<uint8_t> vertUniforms;
 	std::vector<uint8_t> fragUniforms;
 	std::string name;

--- a/lib/mzgl/gl/api/sokol/SokolVbo.cpp
+++ b/lib/mzgl/gl/api/sokol/SokolVbo.cpp
@@ -70,41 +70,34 @@ static sg_primitive_type primitiveTypeToSokolMode(Vbo::PrimitiveType mode) {
 void SokolVbo::draw_(Graphics &g, Vbo::PrimitiveType mode, size_t numInstances) {
 	auto shader = getShader(g);
 
-	std::vector<sg_vertex_format> attrs = {positionBuffer.getFormat()};
-
 	if (!positionBuffer.valid()) {
 		printf("position buffer not valid\n");
 		return;
 	}
-	// vbo chooses the shader
-	sg_bindings bindings		= {};
-	bindings.vertex_buffers[0]	= positionBuffer.buffer;
-	int nextPos					= 1;
 
-	// Order matters: each buffer at slot i feeds the shader attribute at location
-	// i (SokolPipeline sets buffer_index = i). Every shader declares its vertex
-	// attributes as Position, then TexCoord, then Color, so texcoords must be
-	// bound before colors. Binding color first swaps the two for the color+
-	// texcoord shaders (colorFont/colorTexture): TexCoord then reads colour data
-	// and samples a constant atlas texel - e.g. grid keyboard note names render
-	// as solid black rects.
-	if (texCoordBuffer.valid()) {
-		bindings.vertex_buffers[nextPos] = texCoordBuffer.buffer;
-		attrs.push_back(texCoordBuffer.getFormat());
-		nextPos++;
-	}
+	sg_bindings bindings = {};
+	std::vector<SokolVertexAttr> attrs;
+	int slot = 0;
 
-	if (colorBuffer.valid()) {
-		bindings.vertex_buffers[nextPos] = colorBuffer.buffer;
-		attrs.push_back(colorBuffer.getFormat());
-		nextPos++;
-	}
+	// Bind each vertex buffer to the shader attribute location resolved BY NAME
+	// from the shader's reflection (attrSlot), rather than assuming buffer slot i
+	// feeds attribute location i. This makes the order attributes are declared in
+	// the .glsl irrelevant: shaders that list Color before TexCoord (fx sliders,
+	// piano roll notes) and ones that list TexCoord before Color (font atlas) both
+	// bind correctly. Relying on order silently swaps attributes when they differ.
+	auto bindAttr = [&](Buffer &buf, const char *attrName, bool perInstance = false) {
+		if (!buf.valid()) return;
+		int location = shader->attrSlot(attrName);
+		if (location < 0) return; // shader doesn't declare this attribute
+		bindings.vertex_buffers[slot] = buf.buffer;
+		attrs.push_back({location, buf.getFormat(), slot, perInstance});
+		slot++;
+	};
 
-	if (normalBuffer.valid()) {
-		bindings.vertex_buffers[nextPos] = normalBuffer.buffer;
-		attrs.push_back(normalBuffer.getFormat());
-		nextPos++;
-	}
+	bindAttr(positionBuffer, "Position");
+	bindAttr(colorBuffer, "Color");
+	bindAttr(texCoordBuffer, "TexCoord");
+	bindAttr(normalBuffer, "Normal");
 
 	if (indexBuffer.valid()) {
 		bindings.index_buffer = indexBuffer.buffer;
@@ -118,10 +111,9 @@ void SokolVbo::draw_(Graphics &g, Vbo::PrimitiveType mode, size_t numInstances) 
 			}
 			instanceIndexBuffer.set(counter);
 		}
-		attrs.push_back(instanceIndexBuffer.getFormat());
-		bindings.vertex_buffers[nextPos] = instanceIndexBuffer.buffer;
-		nextPos++;
+		bindAttr(instanceIndexBuffer, "InstanceID", true);
 	}
+
 	auto *api = static_cast<SokolAPI *>(&g.getAPI());
 
 	auto tex = api->getBoundTexture();
@@ -132,7 +124,7 @@ void SokolVbo::draw_(Graphics &g, Vbo::PrimitiveType mode, size_t numInstances) 
 		auto sampler			= api->getSampler();
 		bindings.fs.samplers[0] = sampler;
 	}
-	shader->getPipeline(attrs, indexBuffer.valid(), primitiveTypeToSokolMode(mode), numInstances > 1)->apply();
+	shader->getPipeline(attrs, indexBuffer.valid(), primitiveTypeToSokolMode(mode))->apply();
 
 	sg_apply_bindings(bindings);
 

--- a/lib/mzgl/gl/api/sokol/SokolVertexAttr.h
+++ b/lib/mzgl/gl/api/sokol/SokolVertexAttr.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "sokol_gfx.h"
+
+// Describes how one vertex buffer maps onto a shader's vertex stage:
+//  - location:    the shader attribute slot, resolved by NAME from the shader's
+//                 sokol-shdc reflection (so the order attributes are declared in
+//                 the .glsl is irrelevant)
+//  - format:      the buffer's vertex format
+//  - bufferSlot:  index into sg_bindings.vertex_buffers where the data lives
+//  - perInstance: whether this buffer steps once per instance
+struct SokolVertexAttr {
+	int location			= 0;
+	sg_vertex_format format = SG_VERTEXFORMAT_INVALID;
+	int bufferSlot			= 0;
+	bool perInstance		= false;
+};


### PR DESCRIPTION
## Problem
`SokolVbo::draw_` bound vertex buffers in a fixed order and `SokolPipeline` mapped buffer slot *i* → shader attribute location *i*. That only works if every shader declares attributes in that exact order — but they don't:
- built-in `colorFont`/`colorTexture`: `TexCoord` before `Color`
- app shaders (perform fx sliders, piano-roll notes, …): `Color` before `TexCoord`

So any fixed binding order silently swaps two attributes for one set or the other. The earlier black-rect fix forced texcoord-before-color (fixing the font atlas) but that made the slider/piano-roll shaders read colour data as texcoords → weird gradients.

## Fix
Resolve each buffer's attribute location **by name** from the shader's sokol-shdc reflection (`ShaderDef::attrSlotFunc`, exposed as `SokolShader::attrSlot`) and place it at that location, reading from its own vertex-buffer slot. The pipeline layout is built per-location instead of per-binding-order. Declaration order in the .glsl is now irrelevant. **No shader source changes.**

This restores the name-based binding the backend originally used.

## Verified (Metal, live)
Grid keyboard note names, piano-roll notes, and perform-page fx sliders all render correctly — see screenshots in the thread.