### PR TITLE
Load SVGs from memory to fix crash on non-ASCII install paths (Linux)

### DIFF
--- a/lib/mzgl/geom/SVG.cpp
+++ b/lib/mzgl/geom/SVG.cpp
@@ -752,45 +752,18 @@ bool SVGDoc::loadFromString(const string &svgData) {
 }
 
 bool SVGDoc::load(string path) {
-	defs.clear();
-	pu_gi::xml_document doc;
-
+	std::string data;
 #ifdef __ANDROID__
-	vector<unsigned char> data;
-	loadAndroidAsset(path, data);
-	auto status = doc.load_buffer(data.data(), data.size());
-
-	if (status.status != pu_gi::status_ok) {
-		Log::e() << "Error: Couldn't load svg from buffer - got " << data.size()
-				 << "bytes - message from pu_gi is " << status.description() << " - at character "
-				 << status.offset;
-		return false;
-	}
+	data	= loadAndroidAssetAsString(path);
+	bool ok = !data.empty();
 #else
-
-	// pu_gixml has no interface for utf8 paths
-	// so first convert utf8 to wchar version
-	wstring unicodePath = fs::path(path).wstring();
-	auto status			= doc.load_file((wchar_t *) (unicodePath.c_str()));
-
-	if (status.status != pu_gi::status_ok) {
-		Log::e() << "ERROR: could not load svg - pu_gi says " << status.description() << " - at character "
-				 << status.offset;
+	bool ok = readStringFromFile(path, data);
+#endif
+	if (!ok) {
+		Log::e() << "ERROR: could not read svg file at " << path;
 		return false;
 	}
-#endif
-
-	pu_gi::xml_node root = doc.document_element();
-
-	parseViewBox(root.attribute("viewBox").value());
-	width  = viewBox.width;
-	height = viewBox.height;
-	parseDefs(root);
-
-	rootGroup = SVGGroup::create(root, defs);
-
-	rootGroup->applyState();
-	return true;
+	return loadFromString(data);
 }
 
 void SVGDoc::getTriangles(vector<glm::vec2> &verts, vector<glm::vec4> &cols, vector<unsigned int> &indices) {


### PR DESCRIPTION
## Problem

`SVGDoc::load` converted the file path with `fs::path(path).wstring()` before handing it to pugixml. On Linux, libstdc++'s `path::wstring()` throws `filesystem_error: "Cannot convert character sequence"` for **any non-ASCII path, in every locale configuration** (verified with a standalone test: UTF-8 `é`, Latin-1 `é`, `C.UTF-8`, `fr_FR.UTF-8`, with and without `setlocale` — all throw).

So a user who unzips Koala into e.g. `~/Téléchargements/` crashes: the throw either escapes into `KoalaApp::setup`'s catch (EXCEPTION dialog, `error.txt`, half-initialized app → SEGV shortly after) or escapes uncaught later (piano roll `KeyboardToggle`, `KeyboardButton` layout on pro-status change) → `std::terminate`. Reproduced and symbolicated both on Linux.

## Fix

Read the file ourselves with `readStringFromFile` — whose `u8path` is byte-transparent on POSIX and does the proper UTF-8→wide conversion on Windows — and parse via the existing `loadFromString`, mirroring what the Android asset branch already does. No platform ifdef around the pugixml call needed anymore.

Side benefit: the file path now shares `loadFromString`'s parse code, so it picks up the width/height fallback for SVGs lacking a viewBox, which the old file branch didn't have.

## Verification

- Debug + release Koala builds launched from a `téléchargements/` install dir under `fr_FR.UTF-8`: no more throw, no `error.txt`, no crash; behavior identical to an ASCII path.
- Koala's `[svg-tri]` tests pass, and the hidden `svg triangulation full scale sweep` (loads every SVG in `data/svg` from file at many scales) passes, exercising the new read-then-parse path over the whole icon set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpyvHteyNSYHSxFdwSjT8b